### PR TITLE
Get tests running on Windows CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,4 +65,6 @@ jobs:
 
       - name: Test
         working-directory: ${{ env.BUILD_DIR }}
-        run: ctest --output-on-failure -j4 -VV
+        run: |
+          ls -ahl
+          ctest --output-on-failure -j4 -VV

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Configure
         shell: bash
-        run: cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache .
+        run: cmake -B ${{ env.BUILD_DIR }} -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache .
 
       - name: Build
         shell: bash
@@ -65,6 +65,4 @@ jobs:
 
       - name: Test
         working-directory: ${{ env.BUILD_DIR }}
-        run: |
-          ls -ahl
-          ctest --output-on-failure -j4 -VV
+        run: ctest --output-on-failure -j4 -VV


### PR DESCRIPTION
Windows tests are passing locally, but not in CI.

```
CMake Error at _deps/catch2-src/extras/CatchAddTests.cmake:70 (message):
  Error running test executable
  'D:/a/melatonin_blur/melatonin_blur/Builds/Tests.exe':

    Result: Exit code 0xc0000139

  

    Output: 

Call Stack (most recent call first):
  _deps/catch2-src/extras/CatchAddTests.cmake:175 (catch_discover_tests_impl)
```

Seems to be some loader / dll issue?...