### PR TITLE
Move vImage implementation into a cpp file to avoid including Acceler…

### DIFF
--- a/melatonin/implementations/vImage.cpp
+++ b/melatonin/implementations/vImage.cpp
@@ -1,0 +1,114 @@
+//
+// Created by Christian Haase on 18/12/2023.
+//
+
+#include "../internal/implementations.h"
+#if JUCE_MAC && MELATONIN_BLUR_VIMAGE
+#include "Accelerate/Accelerate.h"
+
+namespace melatonin::blur
+{
+    std::vector<float> createFloatKernel (size_t radius)
+    {
+        // The kernel size is always odd
+        size_t kernelSize = radius * 2 + 1;
+
+        // This is the divisor for the kernel
+        // If you are familiar with stack blur, it's the size of the stack
+        auto divisor = float (radius + 1) * (float) (radius + 1);
+
+        std::vector<float> kernel (kernelSize);
+
+        // Manufacture the stack blur-esque kernel
+        // For example, for radius of 2:
+        // 1/9 2/9 3/9 2/9 1/9
+        for (size_t i = 0; i < kernelSize; ++i)
+        {
+            auto distance = (size_t) std::abs ((int) i - (int) radius);
+            kernel[i] = (float) (radius + 1 - distance) / divisor;
+        }
+
+        return kernel;
+    }
+
+    void vImageSingleChannel (juce::Image& img, size_t radius)
+    {
+        const auto w = (unsigned int) img.getWidth();
+        const auto h = (unsigned int) img.getHeight();
+        juce::Image::BitmapData data (img, juce::Image::BitmapData::readWrite);
+
+        auto kernel = createFloatKernel (radius);
+
+        // vdsp convolution isn't happy operating in-place, unfortunately
+        auto copy = img.createCopy();
+        juce::Image::BitmapData copyData (copy, juce::Image::BitmapData::readOnly);
+        vImage_Buffer src = { copyData.getLinePointer (0), h, w, (size_t) data.lineStride };
+
+        vImage_Buffer dst = { data.getLinePointer (0), h, w, (size_t) data.lineStride };
+        vImageSepConvolve_Planar8 (&src, &dst, nullptr, 0, 0, kernel.data(), (unsigned int) kernel.size(), kernel.data(), (unsigned int) kernel.size(), 0, Pixel_16U(), kvImageEdgeExtend);
+    }
+
+    // currently unused, may be benchmarked vs. drawImageAt
+    juce::Image convertToARGB (juce::Image& src, juce::Colour color)
+    {
+        jassert (src.getFormat() == juce::Image::SingleChannel);
+        juce::Image dst (juce::Image::ARGB, src.getWidth(), src.getHeight(), true);
+        juce::Image::BitmapData srcData (src, juce::Image::BitmapData::readOnly);
+        juce::Image::BitmapData dstData (dst, juce::Image::BitmapData::readWrite);
+        vImage_Buffer alphaBuffer = { srcData.getLinePointer (0), static_cast<vImagePixelCount> (src.getHeight()), static_cast<vImagePixelCount> (src.getWidth()), static_cast<size_t> (srcData.lineStride) };
+        vImage_Buffer dstBuffer = { dstData.getLinePointer (0), static_cast<vImagePixelCount> (dst.getHeight()), static_cast<vImagePixelCount> (dst.getWidth()), static_cast<size_t> (dstData.lineStride) };
+
+        // vdsp doesn't have a Planar8toBGRA function, so we just shuffle the channels manually
+        // (and assume we're always little endian)
+        vImageConvert_Planar8toARGB8888 (&alphaBuffer, &alphaBuffer, &alphaBuffer, &alphaBuffer, &dstBuffer, kvImageNoFlags);
+        vImageOverwriteChannelsWithScalar_ARGB8888 (color.getRed(), &dstBuffer, &dstBuffer, 0x2, kvImageNoFlags);
+        vImageOverwriteChannelsWithScalar_ARGB8888 (color.getGreen(), &dstBuffer, &dstBuffer, 0x4, kvImageNoFlags);
+        vImageOverwriteChannelsWithScalar_ARGB8888 (color.getBlue(), &dstBuffer, &dstBuffer, 0x8, kvImageNoFlags);
+
+        // BGRA = little endian ARGB
+        vImagePremultiplyData_BGRA8888 (&dstBuffer, &dstBuffer, kvImageNoFlags);
+        return dst;
+    }
+
+    void tentBlurSingleChannel (juce::Image& img, unsigned int radius)
+    {
+        const unsigned int w = (unsigned int) img.getWidth();
+        const unsigned int h = (unsigned int) img.getHeight();
+
+        juce::Image::BitmapData data (img, juce::Image::BitmapData::readWrite);
+
+        vImage_Buffer src = { data.getLinePointer (0), h, w, (size_t) data.lineStride };
+        vImage_Buffer dst = { data.getLinePointer (0), h, w, (size_t) data.lineStride };
+        vImageTentConvolve_Planar8 (
+            &src,
+            &dst,
+            nullptr,
+            0,
+            0,
+            radius * 2 + 1,
+            radius * 2 + 1,
+            0,
+            kvImageEdgeExtend);
+    }
+
+#if MELATONIN_BLUR_VIMAGE_MACOS14
+    void vImageARGB (juce::Image& srcImage, juce::Image& dstImage, size_t radius)
+    {
+        jassert (srcImage.getFormat() == juce::Image::PixelFormat::ARGB);
+
+        auto kernel = createFloatKernel (radius);
+
+        const auto w = (unsigned int) srcImage.getWidth();
+        const auto h = (unsigned int) srcImage.getHeight();
+        juce::Image::BitmapData srcData (srcImage, juce::Image::BitmapData::readWrite);
+        juce::Image::BitmapData dstData (dstImage, juce::Image::BitmapData::readWrite);
+
+        // vImageSepConvolve isn't happy operating in-place
+        vImage_Buffer src = { srcData.getLinePointer (0), h, w, (size_t) srcData.lineStride };
+        vImage_Buffer dst = { dstData.getLinePointer (0), h, w, (size_t) dstData.lineStride };
+        vImageSepConvolve_ARGB8888 (&src, &dst, nullptr, 0, 0, kernel.data(), (unsigned int) kernel.size(), kernel.data(), (unsigned int) kernel.size(), 0, Pixel_8888 { 0, 0, 0, 0 }, kvImageEdgeExtend);
+    }
+#endif
+}
+
+#endif

--- a/melatonin/implementations/vImage.h
+++ b/melatonin/implementations/vImage.h
@@ -1,89 +1,14 @@
 #pragma once
-#include "Accelerate/Accelerate.h"
 #include "juce_gui_basics/juce_gui_basics.h"
 
 namespace melatonin::blur
 {
-    static inline std::vector<float> createFloatKernel (size_t radius)
-    {
-        // The kernel size is always odd
-        size_t kernelSize = radius * 2 + 1;
+    std::vector<float> createFloatKernel (size_t radius);
 
-        // This is the divisor for the kernel
-        // If you are familiar with stack blur, it's the size of the stack
-        auto divisor = float (radius + 1) * (float) (radius + 1);
-
-        std::vector<float> kernel (kernelSize);
-
-        // Manufacture the stack blur-esque kernel
-        // For example, for radius of 2:
-        // 1/9 2/9 3/9 2/9 1/9
-        for (size_t i = 0; i < kernelSize; ++i)
-        {
-            auto distance = (size_t) std::abs ((int) i - (int) radius);
-            kernel[i] = (float) (radius + 1 - distance) / divisor;
-        }
-
-        return kernel;
-    }
-
-    static inline void vImageSingleChannel (juce::Image& img, size_t radius)
-    {
-        const auto w = (unsigned int) img.getWidth();
-        const auto h = (unsigned int) img.getHeight();
-        juce::Image::BitmapData data (img, juce::Image::BitmapData::readWrite);
-
-        auto kernel = createFloatKernel (radius);
-
-        // vdsp convolution isn't happy operating in-place, unfortunately
-        auto copy = img.createCopy();
-        juce::Image::BitmapData copyData (copy, juce::Image::BitmapData::readOnly);
-        vImage_Buffer src = { copyData.getLinePointer (0), h, w, (size_t) data.lineStride };
-
-        vImage_Buffer dst = { data.getLinePointer (0), h, w, (size_t) data.lineStride };
-        vImageSepConvolve_Planar8 (&src, &dst, nullptr, 0, 0, kernel.data(), (unsigned int) kernel.size(), kernel.data(), (unsigned int) kernel.size(), 0, Pixel_16U(), kvImageEdgeExtend);
-    }
+    void vImageSingleChannel (juce::Image& img, size_t radius);
 
     // currently unused, may be benchmarked vs. drawImageAt
-    static juce::Image convertToARGB (juce::Image& src, juce::Colour color)
-    {
-        jassert (src.getFormat() == juce::Image::SingleChannel);
-        juce::Image dst (juce::Image::ARGB, src.getWidth(), src.getHeight(), true);
-        juce::Image::BitmapData srcData (src, juce::Image::BitmapData::readOnly);
-        juce::Image::BitmapData dstData (dst, juce::Image::BitmapData::readWrite);
-        vImage_Buffer alphaBuffer = { srcData.getLinePointer (0), static_cast<vImagePixelCount> (src.getHeight()), static_cast<vImagePixelCount> (src.getWidth()), static_cast<size_t> (srcData.lineStride) };
-        vImage_Buffer dstBuffer = { dstData.getLinePointer (0), static_cast<vImagePixelCount> (dst.getHeight()), static_cast<vImagePixelCount> (dst.getWidth()), static_cast<size_t> (dstData.lineStride) };
+    juce::Image convertToARGB (juce::Image& src, juce::Colour color);
 
-        // vdsp doesn't have a Planar8toBGRA function, so we just shuffle the channels manually
-        // (and assume we're always little endian)
-        vImageConvert_Planar8toARGB8888 (&alphaBuffer, &alphaBuffer, &alphaBuffer, &alphaBuffer, &dstBuffer, kvImageNoFlags);
-        vImageOverwriteChannelsWithScalar_ARGB8888 (color.getRed(), &dstBuffer, &dstBuffer, 0x2, kvImageNoFlags);
-        vImageOverwriteChannelsWithScalar_ARGB8888 (color.getGreen(), &dstBuffer, &dstBuffer, 0x4, kvImageNoFlags);
-        vImageOverwriteChannelsWithScalar_ARGB8888 (color.getBlue(), &dstBuffer, &dstBuffer, 0x8, kvImageNoFlags);
-
-        // BGRA = little endian ARGB
-        vImagePremultiplyData_BGRA8888 (&dstBuffer, &dstBuffer, kvImageNoFlags);
-        return dst;
-    }
-
-    static void tentBlurSingleChannel (juce::Image& img, unsigned int radius)
-    {
-        const unsigned int w = (unsigned int) img.getWidth();
-        const unsigned int h = (unsigned int) img.getHeight();
-
-        juce::Image::BitmapData data (img, juce::Image::BitmapData::readWrite);
-
-        vImage_Buffer src = { data.getLinePointer (0), h, w, (size_t) data.lineStride };
-        vImage_Buffer dst = { data.getLinePointer (0), h, w, (size_t) data.lineStride };
-        vImageTentConvolve_Planar8 (
-            &src,
-            &dst,
-            nullptr,
-            0,
-            0,
-            radius * 2 + 1,
-            radius * 2 + 1,
-            0,
-            kvImageEdgeExtend);
-    }
+    void tentBlurSingleChannel (juce::Image& img, unsigned int radius);
 }

--- a/melatonin/implementations/vImage_macOS14.h
+++ b/melatonin/implementations/vImage_macOS14.h
@@ -1,24 +1,8 @@
 #pragma once
-#include "Accelerate/Accelerate.h"
 #include "juce_gui_basics/juce_gui_basics.h"
 #include "vImage.h"
 
 namespace melatonin::blur
 {
-    static inline void vImageARGB (juce::Image& srcImage, juce::Image& dstImage, size_t radius)
-    {
-        jassert (srcImage.getFormat() == juce::Image::PixelFormat::ARGB);
-
-        auto kernel = createFloatKernel (radius);
-
-        const auto w = (unsigned int) srcImage.getWidth();
-        const auto h = (unsigned int) srcImage.getHeight();
-        juce::Image::BitmapData srcData (srcImage, juce::Image::BitmapData::readWrite);
-        juce::Image::BitmapData dstData (dstImage, juce::Image::BitmapData::readWrite);
-
-        // vImageSepConvolve isn't happy operating in-place
-        vImage_Buffer src = { srcData.getLinePointer (0), h, w, (size_t) srcData.lineStride };
-        vImage_Buffer dst = { dstData.getLinePointer (0), h, w, (size_t) dstData.lineStride };
-        vImageSepConvolve_ARGB8888 (&src, &dst, nullptr, 0, 0, kernel.data(), (unsigned int) kernel.size(), kernel.data(), (unsigned int) kernel.size(), 0, Pixel_8888 { 0, 0, 0, 0 }, kvImageEdgeExtend);
-    }
+    void vImageARGB (juce::Image& srcImage, juce::Image& dstImage, size_t radius);
 }

--- a/melatonin_blur.cpp
+++ b/melatonin_blur.cpp
@@ -1,3 +1,5 @@
+#include "melatonin/implementations/vImage.cpp"
+
 #if RUN_MELATONIN_TESTS
     #include "benchmarks/benchmarks.cpp"
     #include "tests/blur_implementations.cpp"

--- a/tests/drop_shadow.cpp
+++ b/tests/drop_shadow.cpp
@@ -288,6 +288,7 @@ TEST_CASE ("Melatonin Blur Drop Shadow")
 }
 
 #if JUCE_MAC
+#include "Accelerate/Accelerate.h"
 // Verify what macOS and JUCE are doing at the raw pixel level
 TEST_CASE ("Melatonin Blur JUCE premultiplied check")
 {


### PR DESCRIPTION
Turns out the `Accelerate.h` header has a `typedef Point`, so when I imported the library into my project where I have `using namespace juce` (I know..) it clashed with `juce::Point`. I had to move the `Accelerate.h` into a cpp file in order to get it to compile on Mac (no pains on Windows). Maybe it's also desirable to hide that header for better encapsulation?

What I'm unsure of:
- I'm not sure how or if it affects performance in any way. Maybe CI will tell. I did a quick run of the benchmarks before/after the edits on my own macbook, but they were kinda hard to compare as they were very different (also the reference implementations).
- If I used the preprocessor defs correctly - will this work on MacOS 14?
- Should I keep the `static` on the function declarations?