### PR TITLE
Hide implementations from module header

### DIFF
--- a/benchmarks/benchmarks.cpp
+++ b/benchmarks/benchmarks.cpp
@@ -6,6 +6,7 @@
 #include "melatonin_blur/melatonin_blur.h"
 #include "../melatonin/implementations/naive.h"
 #include "../melatonin/implementations/float_vector_stack_blur.h"
+#include "../melatonin/internal/implementations.h"
 
 // other benchmarks
 #include "single_channel.cpp"

--- a/melatonin/cached_blur.cpp
+++ b/melatonin/cached_blur.cpp
@@ -1,0 +1,39 @@
+#include "internal/rendered_single_channel_shadow.h"
+#include "internal/implementations.h"
+
+namespace melatonin
+{
+
+CachedBlur::CachedBlur (size_t r) : radius (r)
+{
+    jassert (radius > 0);
+}
+
+void CachedBlur::update (const juce::Image& newSource)
+{
+    if (newSource != src)
+    {
+        jassert (newSource.isValid());
+        src = newSource;
+
+        // the first time the blur is created, a copy is needed
+        // so we are passing correct dimensions, etc to the blur algo
+        dst = src.createCopy();
+        melatonin::blur::argb (src, dst, radius);
+    }
+}
+
+juce::Image& CachedBlur::render (juce::Image& newSource)
+{
+    update (newSource);
+    return dst;
+}
+
+juce::Image& CachedBlur::render()
+{
+    // You either need to have called update or rendered with a src!
+    jassert (dst.isValid());
+    return dst;
+}
+
+}

--- a/melatonin/cached_blur.h
+++ b/melatonin/cached_blur.h
@@ -1,44 +1,18 @@
 #pragma once
-#include "internal/rendered_single_channel_shadow.h"
 
 namespace melatonin
 {
     class CachedBlur
     {
     public:
-        explicit CachedBlur (size_t r) : radius (r)
-        {
-            jassert (radius > 0);
-        }
+        explicit CachedBlur (size_t r);
 
         // we are passing the source by value here
         // (but it's a value object of sorts since its reference counted)
-        void update (const juce::Image& newSource)
-        {
-            if (newSource != src)
-            {
-                jassert (newSource.isValid());
-                src = newSource;
+        void update (const juce::Image& newSource);
 
-                // the first time the blur is created, a copy is needed
-                // so we are passing correct dimensions, etc to the blur algo
-                dst = src.createCopy();
-                melatonin::blur::argb (src, dst, radius);
-            }
-        }
-
-        juce::Image& render (juce::Image& newSource)
-        {
-            update (newSource);
-            return dst;
-        }
-
-        juce::Image& render()
-        {
-            // You either need to have called update or rendered with a src!
-            jassert (dst.isValid());
-            return dst;
-        }
+        juce::Image& render (juce::Image& newSource);
+        juce::Image& render();
 
     private:
         // juce::Images are value objects, reference counted behind the scenes

--- a/melatonin/internal/cached_shadows.cpp
+++ b/melatonin/internal/cached_shadows.cpp
@@ -326,8 +326,8 @@ void CachedShadows::compositeShadowsToARGB()
         // it will literally g2.fillAll() with the shadow's color
         // using the shadow's image as a sort of mask
         g2.drawImageAt (shadow.getImage(), shadowOffsetFromComposite.getX(), shadowOffsetFromComposite.getY(), true);
+        }
+        needsRecomposite = false;
     }
-    needsRecomposite = false;
-}
 
 } // namespace melatonin::internal

--- a/melatonin/internal/cached_shadows.cpp
+++ b/melatonin/internal/cached_shadows.cpp
@@ -1,0 +1,333 @@
+namespace melatonin::internal
+{
+
+CachedShadows::CachedShadows (std::initializer_list<ShadowParameters> shadowParameters, bool force_inner)
+{
+    // gotta feed some shadows!
+    jassert (shadowParameters.size() > 0);
+
+    for (auto& parameters : shadowParameters)
+    {
+        auto& shadow = renderedSingleChannelShadows.emplace_back (parameters);
+
+        if (force_inner)
+            shadow.parameters.inner = true;
+    }
+}
+
+void CachedShadows::render (juce::Graphics& g, const juce::Path& newPath, bool lowQuality)
+{
+    setScale (g, lowQuality);
+
+    // Store a copy of the path.
+    juce::Path pathCopy (newPath);
+
+    // If it's new to us, strip its location and store its float x/y offset to 0,0
+    updatePathIfNeeded (pathCopy);
+
+    renderInternal (g);
+}
+
+void CachedShadows::render (juce::Graphics& g, const juce::Path& newPath, const juce::PathStrokeType& newType, bool lowQuality)
+{
+    stroked = true;
+    setScale (g, lowQuality);
+    if (newType != strokeType)
+    {
+        strokeType = newType;
+        needsRecalculate = true;
+    }
+
+    // Stroking the path changes its bounds.
+    // Do this before we strip the origin and compare with cache.
+    juce::Path strokedPath;
+    strokeType.createStrokedPath (strokedPath, newPath, {}, scale);
+
+    updatePathIfNeeded (strokedPath);
+
+    renderInternal (g);
+}
+
+void CachedShadows::render (juce::Graphics& g, const juce::String& text, const juce::Rectangle<float>& area, juce::Justification justification)
+{
+    setScale (g, false);
+
+    // TODO: right now if text is repositioned it *will* break blur cache
+    // This seems favorable than calling arrangement.createPath on each call?
+    // But if you are animating text shadows and grumpy at performance, please open an issue :)
+    TextArrangement newTextArrangement { text, g.getCurrentFont(), area, justification };
+    if (newTextArrangement != lastTextArrangement)
+    {
+        lastTextArrangement = newTextArrangement;
+        juce::GlyphArrangement arr;
+        arr.addLineOfText (g.getCurrentFont(), text, area.getX(), area.getY());
+        arr.justifyGlyphs (0, arr.getNumGlyphs(), area.getX(), area.getY(), area.getWidth(), area.getHeight(), justification);
+        juce::Path path;
+        arr.createPath (path);
+        updatePathIfNeeded (path);
+    }
+
+    renderInternal (g);
+    // need to still render a path here, which path?
+}
+
+void CachedShadows::render (juce::Graphics& g, const juce::String& text, const juce::Rectangle<int>& area, juce::Justification justification)
+{
+    render (g, text, area.toFloat(), justification);
+}
+
+void CachedShadows::render (juce::Graphics& g, const juce::String& text, int x, int y, int width, int height, juce::Justification justification)
+{
+    render (g, text, juce::Rectangle<int> (x, y, width, height).toFloat(), justification);
+}
+
+void CachedShadows::setRadius (size_t radius, size_t index)
+{
+    if (index < renderedSingleChannelShadows.size())
+        needsRecalculate = renderedSingleChannelShadows[index].updateRadius ((int) radius);
+}
+
+void CachedShadows::setSpread (size_t spread, size_t index)
+{
+    if (index < renderedSingleChannelShadows.size())
+        needsRecalculate = renderedSingleChannelShadows[index].updateSpread ((int) spread);
+}
+
+void CachedShadows::setOffset (juce::Point<int> offset, size_t index)
+{
+    if (index < renderedSingleChannelShadows.size())
+        needsRecomposite = renderedSingleChannelShadows[index].updateOffset (offset, scale);
+}
+
+void CachedShadows::setColor (juce::Colour color, size_t index)
+{
+    if (index < renderedSingleChannelShadows.size())
+        needsRecomposite = renderedSingleChannelShadows[index].updateColor (color);
+}
+
+void CachedShadows::setOpacity (float opacity, size_t index)
+{
+    if (index < renderedSingleChannelShadows.size())
+        needsRecomposite = renderedSingleChannelShadows[index].updateOpacity (opacity);
+}
+
+bool CachedShadows::TextArrangement::operator== (const TextArrangement& other) const
+{
+    return text == other.text && font == other.font && area == other.area && justification == other.justification;
+}
+
+bool CachedShadows::TextArrangement::operator!= (const TextArrangement& other) const
+{
+    return !(*this == other);
+}
+
+void CachedShadows::setScale (juce::Graphics& g, bool lowQuality)
+{
+    // Before Melatonin Blur, it was all low quality!
+    float newScale = 1.0;
+    if (!lowQuality)
+        newScale = g.getInternalContext().getPhysicalPixelScaleFactor();
+
+    // break cache if we're painting on a different monitor, etc
+    if (!juce::approximatelyEqual (scale, newScale))
+    {
+        needsRecalculate = true;
+        scale = newScale;
+    }
+}
+
+void CachedShadows::updatePathIfNeeded (juce::Path& pathToBlur)
+{
+    // stripping the origin lets us animate/translate paths in our UI without breaking blur cache
+    auto incomingOrigin = pathToBlur.getBounds().getPosition();
+    pathToBlur.applyTransform (juce::AffineTransform::translation (-incomingOrigin));
+
+    // has the path actually changed?
+    if (needsRecalculate || (pathToBlur != lastOriginAgnosticPath))
+    {
+        // we already created a copy (that is passed in here), this is faster than creating another
+        lastOriginAgnosticPath.swapWithPath (pathToBlur);
+
+        // we'll need this later for compositing
+        // TODO: Do we really need to store two copies?
+        lastOriginAgnosticPathScaled = lastOriginAgnosticPath;
+        lastOriginAgnosticPathScaled.applyTransform (juce::AffineTransform::scale (scale));
+
+        // remember the new placement in the context
+        pathPositionInContext = incomingOrigin;
+
+        needsRecalculate = true;
+    }
+    else if (incomingOrigin != pathPositionInContext)
+    {
+        // reposition the cached single channel shadows
+        pathPositionInContext = incomingOrigin;
+    }
+}
+
+void CachedShadows::recalculateBlurs()
+{
+    for (auto& shadow : renderedSingleChannelShadows)
+    {
+        shadow.render (lastOriginAgnosticPath, scale, stroked);
+    }
+    needsRecalculate = false;
+    needsRecomposite = true;
+}
+
+void CachedShadows::renderInternal (juce::Graphics& g)
+{
+    // if it's a new path or the path actually changed, redo the single channel blurs
+    if (needsRecalculate)
+        recalculateBlurs();
+
+    // have any of the shadows changed position/color/opacity OR been recalculated?
+    // if so, recreate the ARGB composite of all the shadows together
+    if (needsRecomposite)
+        compositeShadowsToARGB();
+
+    // draw the cached composite into the main graphics context
+    drawARGBComposite (g);
+}
+
+void CachedShadows::drawARGBComposite (juce::Graphics& g, bool optimizeClipBounds)
+{
+    // support default constructors, 0 radius blurs, etc
+    if (compositedARGB.isNull())
+        return;
+
+    // resets the Clip Region when this scope ends
+    juce::Graphics::ScopedSaveState saveState (g);
+
+    // TODO: requires testing/benchmarking
+    if (optimizeClipBounds)
+    {
+        // don't bother drawing what's inside the path's bounds
+        g.excludeClipRegion (lastOriginAgnosticPath.getBounds().toNearestIntEdges());
+    }
+
+    // draw the composite at full strength
+    // (the composite itself has the colors/opacity/etc)
+    g.setOpacity (1.0);
+
+    // compositedARGB has been scaled by the physical pixel scale factor
+    // (unless lowQuality is true)
+    // we have to pass a 1/scale transform because the context will otherwise try to scale the image up
+    // (which is not what we want, at this point our cached shadow is 1:1 with the context)
+    auto position = scaledCompositePosition + (pathPositionInContext * scale);
+    g.drawImageTransformed (compositedARGB, juce::AffineTransform::translation (position).scaled (1.0f / scale));
+}
+
+void CachedShadows::compositeShadowsToARGB()
+{
+    // figure out the largest bounds we need to composite
+    // this is the union of all the shadow bounds
+    // they should all align with the path at 0,0
+    juce::Rectangle<int> compositeBounds = {};
+    for (auto& s : renderedSingleChannelShadows)
+    {
+        if (s.parameters.inner)
+            compositeBounds = compositeBounds.getUnion (s.getScaledPathBounds());
+        else
+            compositeBounds = compositeBounds.getUnion (s.getScaledBounds());
+    }
+
+    scaledCompositePosition = compositeBounds.getPosition().toFloat();
+
+    if (compositeBounds.isEmpty())
+        return;
+
+    // YET ANOTHER graphics context to efficiently convert the image to ARGB
+    // why? Because later, compositing to the main graphics context (g) is faster
+    // (won't need to specify `fillAlphaChannelWithCurrentBrush` for `drawImageAt`,
+    // which slows down the main compositing by a factor of 2-3x)
+    // see: https://forum.juce.com/t/faster-blur-glassmorphism-ui/43086/76
+    compositedARGB = { juce::Image::ARGB, (int) compositeBounds.getWidth(), (int) compositeBounds.getHeight(), true };
+
+    // we're already scaled up (if needed) so no .addTransform here
+    juce::Graphics g2 (compositedARGB);
+
+    for (auto& shadow : renderedSingleChannelShadows)
+    {
+        // TODO: no reason for this scaled copy to be in the loop
+        auto pathCopy = lastOriginAgnosticPathScaled;
+
+        auto shadowPosition = shadow.getScaledBounds().getPosition();
+
+        // this particular single channel blur might have a different offset from the overall composite
+        auto shadowOffsetFromComposite = shadowPosition - compositeBounds.getPosition();
+
+        // lets us temporarily clip the region if needed
+        juce::Graphics::ScopedSaveState saveState (g2);
+
+        g2.setColour (shadow.parameters.color);
+
+        // for inner shadows, clip to the path bounds
+        // we are doing this here instead of in the single channel render
+        // because we want the render to contain the full shadow
+        // so it's cheap to move / recolor / etc
+        if (shadow.parameters.inner)
+        {
+            // we've already saved the state, now clip to the path
+            // this needs to be a path, not bounds!
+            // the goal is to not paint anything outside of these bounds
+            // TODO: This fails for stroked paths!
+            g2.reduceClipRegion (pathCopy);
+
+            // Inner shadows often have areas which needed to be filled with pure shadow colors
+            // For example, when offsets are greater than radius
+            // This matches figma, css, etc.
+            // Otherwise the shadow will be clipped (and have a hard edge).
+            // Since the shadows are square and at integer pixels,
+            // we fill the edges that lie between our shadow and path bounds
+
+            // where is our square cached shadow relative to our composite
+            auto shadowBounds = shadow.getScaledBounds();
+
+            /* In the case the shadow is smaller (due to spread):
+
+                ptl┌───────────────┐
+                   │               │
+                   │  stl┌───┐     │
+                   │     │   │     │
+                   │     └───┘sbr  │
+                   │               │
+                   └───────────────┘pbr
+
+             Or the shadow image doesn't fully cover the path (offset > radius)
+                  stl┌──────────┐
+                     │          │
+               ptl┌──┼──┐       │
+                  │  │  │       │
+                  │  │  │       │
+                  └──┼──┘pbr    │
+                     │          │
+                     └──────────┘sbr
+
+             */
+            auto ptl = shadow.getScaledPathBounds().getTopLeft();
+            auto pbr = shadow.getScaledPathBounds().getBottomRight();
+            auto stl = shadowBounds.getTopLeft();
+            auto sbr = shadowBounds.getBottomRight();
+
+            auto topEdge = juce::Rectangle<int> (ptl.x, ptl.y, pbr.x, stl.y);
+            auto leftEdge = juce::Rectangle<int> (ptl.x, ptl.y, stl.x, pbr.y);
+            auto bottomEdge = juce::Rectangle<int> (ptl.x, sbr.y, pbr.x, pbr.y);
+            auto rightEdge = juce::Rectangle<int> (sbr.x, ptl.y, pbr.x, pbr.y);
+
+            g2.fillRect (topEdge);
+            g2.fillRect (leftEdge);
+            g2.fillRect (bottomEdge);
+            g2.fillRect (rightEdge);
+        }
+
+        // "true" means "fill the alpha channel with the current brush" — aka s.color
+        // this is a bit deceptive for the drawImageAt call
+        // it will literally g2.fillAll() with the shadow's color
+        // using the shadow's image as a sort of mask
+        g2.drawImageAt (shadow.getImage(), shadowOffsetFromComposite.getX(), shadowOffsetFromComposite.getY(), true);
+    }
+    needsRecomposite = false;
+}
+
+} // namespace melatonin::internal

--- a/melatonin/internal/cached_shadows.h
+++ b/melatonin/internal/cached_shadows.h
@@ -8,19 +8,7 @@ namespace melatonin::internal
     class CachedShadows
     {
     protected:
-        CachedShadows (std::initializer_list<ShadowParameters> shadowParameters, bool force_inner = false)
-        {
-            // gotta feed some shadows!
-            jassert (shadowParameters.size() > 0);
-
-            for (auto& parameters : shadowParameters)
-            {
-                auto& shadow = renderedSingleChannelShadows.emplace_back (parameters);
-
-                if (force_inner)
-                    shadow.parameters.inner = true;
-            }
-        }
+        CachedShadows (std::initializer_list<ShadowParameters> shadowParameters, bool force_inner = false);
 
     public:
         // store a copy of the path to compare against for caching
@@ -29,101 +17,17 @@ namespace melatonin::internal
         juce::Path lastOriginAgnosticPath = {};
         juce::Path lastOriginAgnosticPathScaled = {};
 
-        void render (juce::Graphics& g, const juce::Path& newPath, bool lowQuality = false)
-        {
-            setScale (g, lowQuality);
+        void render (juce::Graphics& g, const juce::Path& newPath, bool lowQuality = false);
+        void render (juce::Graphics& g, const juce::Path& newPath, const juce::PathStrokeType& newType, bool lowQuality = false);
+        void render (juce::Graphics& g, const juce::String& text, const juce::Rectangle<float>& area, juce::Justification justification);
+        void render (juce::Graphics& g, const juce::String& text, const juce::Rectangle<int>& area, juce::Justification justification);
+        void render (juce::Graphics& g, const juce::String& text, int x, int y, int width, int height, juce::Justification justification);
 
-            // Store a copy of the path.
-            juce::Path pathCopy (newPath);
-
-            // If it's new to us, strip its location and store its float x/y offset to 0,0
-            updatePathIfNeeded (pathCopy);
-
-            renderInternal (g);
-        }
-
-        void render (juce::Graphics& g, const juce::Path& newPath, const juce::PathStrokeType& newType, bool lowQuality = false)
-        {
-            stroked = true;
-            setScale (g, lowQuality);
-            if (newType != strokeType)
-            {
-                strokeType = newType;
-                needsRecalculate = true;
-            }
-
-            // Stroking the path changes its bounds.
-            // Do this before we strip the origin and compare with cache.
-            juce::Path strokedPath;
-            strokeType.createStrokedPath (strokedPath, newPath, {}, scale);
-
-            updatePathIfNeeded (strokedPath);
-
-            renderInternal (g);
-        }
-
-        void render (juce::Graphics& g, const juce::String& text, const juce::Rectangle<float>& area, juce::Justification justification)
-        {
-            setScale (g, false);
-
-            // TODO: right now if text is repositioned it *will* break blur cache
-            // This seems favorable than calling arrangement.createPath on each call?
-            // But if you are animating text shadows and grumpy at performance, please open an issue :)
-            TextArrangement newTextArrangement { text, g.getCurrentFont(), area, justification };
-            if (newTextArrangement != lastTextArrangement)
-            {
-                lastTextArrangement = newTextArrangement;
-                juce::GlyphArrangement arr;
-                arr.addLineOfText (g.getCurrentFont(), text, area.getX(), area.getY());
-                arr.justifyGlyphs (0, arr.getNumGlyphs(), area.getX(), area.getY(), area.getWidth(), area.getHeight(), justification);
-                juce::Path path;
-                arr.createPath (path);
-                updatePathIfNeeded (path);
-            }
-
-            renderInternal (g);
-            // need to still render a path here, which path?
-        }
-
-        void render (juce::Graphics& g, const juce::String& text, const juce::Rectangle<int>& area, juce::Justification justification)
-        {
-            render (g, text, area.toFloat(), justification);
-        }
-
-        void render (juce::Graphics& g, const juce::String& text, int x, int y, int width, int height, juce::Justification justification)
-        {
-            render (g, text, juce::Rectangle<int> (x, y, width, height).toFloat(), justification);
-        }
-
-        void setRadius (size_t radius, size_t index = 0)
-        {
-            if (index < renderedSingleChannelShadows.size())
-                needsRecalculate = renderedSingleChannelShadows[index].updateRadius ((int) radius);
-        }
-
-        void setSpread (size_t spread, size_t index = 0)
-        {
-            if (index < renderedSingleChannelShadows.size())
-                needsRecalculate = renderedSingleChannelShadows[index].updateSpread ((int) spread);
-        }
-
-        void setOffset (juce::Point<int> offset, size_t index = 0)
-        {
-            if (index < renderedSingleChannelShadows.size())
-                needsRecomposite = renderedSingleChannelShadows[index].updateOffset (offset, scale);
-        }
-
-        void setColor (juce::Colour color, size_t index = 0)
-        {
-            if (index < renderedSingleChannelShadows.size())
-                needsRecomposite = renderedSingleChannelShadows[index].updateColor (color);
-        }
-
-        void setOpacity (float opacity, size_t index = 0)
-        {
-            if (index < renderedSingleChannelShadows.size())
-                needsRecomposite = renderedSingleChannelShadows[index].updateOpacity (opacity);
-        }
+        void setRadius (size_t radius, size_t index = 0);
+        void setSpread (size_t spread, size_t index = 0);
+        void setOffset (juce::Point<int> offset, size_t index = 0);
+        void setColor (juce::Colour color, size_t index = 0);
+        void setOpacity (float opacity, size_t index = 0);
 
     private:
         // any float offset from 0,0 the path has is stored here
@@ -152,228 +56,20 @@ namespace melatonin::internal
             juce::Rectangle<float> area = {};
             juce::Justification justification = juce::Justification::left;
 
-            bool operator== (const TextArrangement& other) const
-            {
-                return text == other.text && font == other.font && area == other.area && justification == other.justification;
-            }
-
-            bool operator!= (const TextArrangement& other) const
-            {
-                return !(*this == other);
-            }
+            bool operator== (const TextArrangement& other) const;
+            bool operator!= (const TextArrangement& other) const;
         };
 
         TextArrangement lastTextArrangement = {};
 
-        void setScale (juce::Graphics& g, bool lowQuality)
-        {
-            // Before Melatonin Blur, it was all low quality!
-            float newScale = 1.0;
-            if (!lowQuality)
-                newScale = g.getInternalContext().getPhysicalPixelScaleFactor();
-
-            // break cache if we're painting on a different monitor, etc
-            if (!juce::approximatelyEqual (scale, newScale))
-            {
-                needsRecalculate = true;
-                scale = newScale;
-            }
-        }
-
-        void updatePathIfNeeded (juce::Path& pathToBlur)
-        {
-            // stripping the origin lets us animate/translate paths in our UI without breaking blur cache
-            auto incomingOrigin = pathToBlur.getBounds().getPosition();
-            pathToBlur.applyTransform (juce::AffineTransform::translation (-incomingOrigin));
-
-            // has the path actually changed?
-            if (needsRecalculate || (pathToBlur != lastOriginAgnosticPath))
-            {
-                // we already created a copy (that is passed in here), this is faster than creating another
-                lastOriginAgnosticPath.swapWithPath (pathToBlur);
-
-                // we'll need this later for compositing
-                // TODO: Do we really need to store two copies?
-                lastOriginAgnosticPathScaled = lastOriginAgnosticPath;
-                lastOriginAgnosticPathScaled.applyTransform (juce::AffineTransform::scale (scale));
-
-                // remember the new placement in the context
-                pathPositionInContext = incomingOrigin;
-
-                needsRecalculate = true;
-            }
-            else if (incomingOrigin != pathPositionInContext)
-            {
-                // reposition the cached single channel shadows
-                pathPositionInContext = incomingOrigin;
-            }
-        }
-
-        void recalculateBlurs()
-        {
-            for (auto& shadow : renderedSingleChannelShadows)
-            {
-                shadow.render (lastOriginAgnosticPath, scale, stroked);
-            }
-            needsRecalculate = false;
-            needsRecomposite = true;
-        }
-
-        void renderInternal (juce::Graphics& g)
-        {
-            // if it's a new path or the path actually changed, redo the single channel blurs
-            if (needsRecalculate)
-                recalculateBlurs();
-
-            // have any of the shadows changed position/color/opacity OR been recalculated?
-            // if so, recreate the ARGB composite of all the shadows together
-            if (needsRecomposite)
-                compositeShadowsToARGB();
-
-            // draw the cached composite into the main graphics context
-            drawARGBComposite (g);
-        }
-
-        void drawARGBComposite (juce::Graphics& g, bool optimizeClipBounds = false)
-        {
-            // support default constructors, 0 radius blurs, etc
-            if (compositedARGB.isNull())
-                return;
-
-            // resets the Clip Region when this scope ends
-            juce::Graphics::ScopedSaveState saveState (g);
-
-            // TODO: requires testing/benchmarking
-            if (optimizeClipBounds)
-            {
-                // don't bother drawing what's inside the path's bounds
-                g.excludeClipRegion (lastOriginAgnosticPath.getBounds().toNearestIntEdges());
-            }
-
-            // draw the composite at full strength
-            // (the composite itself has the colors/opacity/etc)
-            g.setOpacity (1.0);
-
-            // compositedARGB has been scaled by the physical pixel scale factor
-            // (unless lowQuality is true)
-            // we have to pass a 1/scale transform because the context will otherwise try to scale the image up
-            // (which is not what we want, at this point our cached shadow is 1:1 with the context)
-            auto position = scaledCompositePosition + (pathPositionInContext * scale);
-            g.drawImageTransformed (compositedARGB, juce::AffineTransform::translation (position).scaled (1.0f / scale));
-        }
+        void setScale (juce::Graphics& g, bool lowQuality);
+        void updatePathIfNeeded (juce::Path& pathToBlur);
+        void recalculateBlurs();
+        void renderInternal (juce::Graphics& g);
+        void drawARGBComposite (juce::Graphics& g, bool optimizeClipBounds = false);
 
         // This is done at the main graphics context scale
         // The path is at 0,0 and the shadows are placed at their correct relative *integer* positions
-        void compositeShadowsToARGB()
-        {
-            // figure out the largest bounds we need to composite
-            // this is the union of all the shadow bounds
-            // they should all align with the path at 0,0
-            juce::Rectangle<int> compositeBounds = {};
-            for (auto& s : renderedSingleChannelShadows)
-            {
-                if (s.parameters.inner)
-                    compositeBounds = compositeBounds.getUnion (s.getScaledPathBounds());
-                else
-                    compositeBounds = compositeBounds.getUnion (s.getScaledBounds());
-            }
-
-            scaledCompositePosition = compositeBounds.getPosition().toFloat();
-
-            if (compositeBounds.isEmpty())
-                return;
-
-            // YET ANOTHER graphics context to efficiently convert the image to ARGB
-            // why? Because later, compositing to the main graphics context (g) is faster
-            // (won't need to specify `fillAlphaChannelWithCurrentBrush` for `drawImageAt`,
-            // which slows down the main compositing by a factor of 2-3x)
-            // see: https://forum.juce.com/t/faster-blur-glassmorphism-ui/43086/76
-            compositedARGB = { juce::Image::ARGB, (int) compositeBounds.getWidth(), (int) compositeBounds.getHeight(), true };
-
-            // we're already scaled up (if needed) so no .addTransform here
-            juce::Graphics g2 (compositedARGB);
-
-            for (auto& shadow : renderedSingleChannelShadows)
-            {
-                // TODO: no reason for this scaled copy to be in the loop
-                auto pathCopy = lastOriginAgnosticPathScaled;
-
-                auto shadowPosition = shadow.getScaledBounds().getPosition();
-
-                // this particular single channel blur might have a different offset from the overall composite
-                auto shadowOffsetFromComposite = shadowPosition - compositeBounds.getPosition();
-
-                // lets us temporarily clip the region if needed
-                juce::Graphics::ScopedSaveState saveState (g2);
-
-                g2.setColour (shadow.parameters.color);
-
-                // for inner shadows, clip to the path bounds
-                // we are doing this here instead of in the single channel render
-                // because we want the render to contain the full shadow
-                // so it's cheap to move / recolor / etc
-                if (shadow.parameters.inner)
-                {
-                    // we've already saved the state, now clip to the path
-                    // this needs to be a path, not bounds!
-                    // the goal is to not paint anything outside of these bounds
-                    // TODO: This fails for stroked paths!
-                    g2.reduceClipRegion (pathCopy);
-
-                    // Inner shadows often have areas which needed to be filled with pure shadow colors
-                    // For example, when offsets are greater than radius
-                    // This matches figma, css, etc.
-                    // Otherwise the shadow will be clipped (and have a hard edge).
-                    // Since the shadows are square and at integer pixels,
-                    // we fill the edges that lie between our shadow and path bounds
-
-                    // where is our square cached shadow relative to our composite
-                    auto shadowBounds = shadow.getScaledBounds();
-
-                    /* In the case the shadow is smaller (due to spread):
-
-                        ptl┌───────────────┐
-                           │               │
-                           │  stl┌───┐     │
-                           │     │   │     │
-                           │     └───┘sbr  │
-                           │               │
-                           └───────────────┘pbr
-
-                     Or the shadow image doesn't fully cover the path (offset > radius)
-                          stl┌──────────┐
-                             │          │
-                       ptl┌──┼──┐       │
-                          │  │  │       │
-                          │  │  │       │
-                          └──┼──┘pbr    │
-                             │          │
-                             └──────────┘sbr
-
-                     */
-                    auto ptl = shadow.getScaledPathBounds().getTopLeft();
-                    auto pbr = shadow.getScaledPathBounds().getBottomRight();
-                    auto stl = shadowBounds.getTopLeft();
-                    auto sbr = shadowBounds.getBottomRight();
-
-                    auto topEdge = juce::Rectangle<int> (ptl.x, ptl.y, pbr.x, stl.y);
-                    auto leftEdge = juce::Rectangle<int> (ptl.x, ptl.y, stl.x, pbr.y);
-                    auto bottomEdge = juce::Rectangle<int> (ptl.x, sbr.y, pbr.x, pbr.y);
-                    auto rightEdge = juce::Rectangle<int> (sbr.x, ptl.y, pbr.x, pbr.y);
-
-                    g2.fillRect (topEdge);
-                    g2.fillRect (leftEdge);
-                    g2.fillRect (bottomEdge);
-                    g2.fillRect (rightEdge);
-                }
-
-                // "true" means "fill the alpha channel with the current brush" — aka s.color
-                // this is a bit deceptive for the drawImageAt call
-                // it will literally g2.fillAll() with the shadow's color
-                // using the shadow's image as a sort of mask
-                g2.drawImageAt (shadow.getImage(), shadowOffsetFromComposite.getX(), shadowOffsetFromComposite.getY(), true);
-            }
-            needsRecomposite = false;
-        }
+        void compositeShadowsToARGB();
     };
 }

--- a/melatonin/internal/rendered_single_channel_shadow.cpp
+++ b/melatonin/internal/rendered_single_channel_shadow.cpp
@@ -1,0 +1,64 @@
+#include "implementations.h"
+
+namespace melatonin::internal
+{
+
+juce::Image& RenderedSingleChannelShadow::render (juce::Path& originAgnosticPath, float scale, bool stroked)
+{
+    scaledPathBounds = (originAgnosticPath.getBounds() * scale).getSmallestIntegerContainer();
+    updateScaledShadowBounds (scale);
+
+    // explicitly support 0 radius shadows and edge spread cases
+    if (parameters.radius < 1 || scaledShadowBounds.isEmpty())
+        singleChannelRender = juce::Image();
+
+    // We can't modify our original path as it would break cache.
+    // Remember, the origin of the path will always be 0,0
+    auto shadowPath = juce::Path (originAgnosticPath);
+
+    if (!stroked && parameters.spread != 0)
+    {
+        // expand the actual path itself
+        // note: this is 1x, it'll be upscaled as needed by fillPath
+        auto bounds = originAgnosticPath.getBounds().expanded (parameters.inner ? (float) -parameters.spread : (float) parameters.spread);
+        shadowPath.scaleToFit (bounds.getX(), bounds.getY(), bounds.getWidth(), bounds.getHeight(), true);
+    }
+
+    // inner shadows are rendered by inverting the path, drop shadowing and clipping to the original path
+    if (parameters.inner)
+    {
+        shadowPath.setUsingNonZeroWinding (false);
+
+        // The outside of our path will be filled with shadow color
+        // which will then cast a blurred shadow inside the path's area.
+        // We need a radius amount of pixels for a strong shadow at the path's edge
+        shadowPath.addRectangle (shadowPath.getBounds().expanded ((float) scaledRadius));
+    }
+
+    // each shadow is its own single channel image associated with a color
+    juce::Image renderedSingleChannel (juce::Image::SingleChannel, scaledShadowBounds.getWidth(), scaledShadowBounds.getHeight(), true);
+
+    // boot up a graphics context to give us access to fillPath, etc
+    juce::Graphics g2 (renderedSingleChannel);
+
+    // ensure we're working at the correct scale
+    g2.addTransform (juce::AffineTransform::scale (scale));
+
+    // cache at full opacity (later composited with the correct color/opacity)
+    g2.setColour (juce::Colours::white);
+
+    // we're still working @1x until fillPath happens
+    // blurContextBounds x/y is negative (relative to path @ 0,0) and we must render in positive space
+    // Note that offset isn't used here,
+    auto unscaledPosition = -scaledShadowBounds.getPosition().toFloat() / scale;
+
+    g2.fillPath (shadowPath, juce::AffineTransform::translation (unscaledPosition));
+
+    // perform the blur with the fastest algorithm available
+    melatonin::blur::singleChannel (renderedSingleChannel, (size_t) scaledRadius);
+
+    singleChannelRender = renderedSingleChannel;
+    return singleChannelRender;
+}
+
+}

--- a/melatonin/internal/rendered_single_channel_shadow.cpp
+++ b/melatonin/internal/rendered_single_channel_shadow.cpp
@@ -5,6 +5,7 @@ namespace melatonin::internal
 
 juce::Image& RenderedSingleChannelShadow::render (juce::Path& originAgnosticPath, float scale, bool stroked)
 {
+    jassert (scale > 0);
     scaledPathBounds = (originAgnosticPath.getBounds() * scale).getSmallestIntegerContainer();
     updateScaledShadowBounds (scale);
 

--- a/melatonin/internal/rendered_single_channel_shadow.h
+++ b/melatonin/internal/rendered_single_channel_shadow.h
@@ -1,6 +1,4 @@
 #pragma once
-
-#include "implementations.h"
 #include "juce_gui_basics/juce_gui_basics.h"
 
 namespace melatonin
@@ -34,64 +32,7 @@ namespace melatonin
 
             explicit RenderedSingleChannelShadow (ShadowParameters p) : parameters (p) {}
 
-            juce::Image& render (juce::Path& originAgnosticPath, float scale, bool stroked = false)
-            {
-                jassert(scale > 0);
-                scaledPathBounds = (originAgnosticPath.getBounds() * scale).getSmallestIntegerContainer();
-                updateScaledShadowBounds (scale);
-
-                // explicitly support 0 radius shadows and edge spread cases
-                if (parameters.radius < 1 || scaledShadowBounds.isEmpty())
-                    singleChannelRender = juce::Image();
-
-                // We can't modify our original path as it would break cache.
-                // Remember, the origin of the path will always be 0,0
-                auto shadowPath = juce::Path (originAgnosticPath);
-
-                if (!stroked && parameters.spread != 0)
-                {
-                    // expand the actual path itself
-                    // note: this is 1x, it'll be upscaled as needed by fillPath
-                    auto bounds = originAgnosticPath.getBounds().expanded (parameters.inner ? (float) -parameters.spread : (float) parameters.spread);
-                    shadowPath.scaleToFit (bounds.getX(), bounds.getY(), bounds.getWidth(), bounds.getHeight(), true);
-                }
-
-                // inner shadows are rendered by inverting the path, drop shadowing and clipping to the original path
-                if (parameters.inner)
-                {
-                    shadowPath.setUsingNonZeroWinding (false);
-
-                    // The outside of our path will be filled with shadow color
-                    // which will then cast a blurred shadow inside the path's area.
-                    // We need a radius amount of pixels for a strong shadow at the path's edge
-                    shadowPath.addRectangle (shadowPath.getBounds().expanded ((float) scaledRadius));
-                }
-
-                // each shadow is its own single channel image associated with a color
-                juce::Image renderedSingleChannel (juce::Image::SingleChannel, scaledShadowBounds.getWidth(), scaledShadowBounds.getHeight(), true);
-
-                // boot up a graphics context to give us access to fillPath, etc
-                juce::Graphics g2 (renderedSingleChannel);
-
-                // ensure we're working at the correct scale
-                g2.addTransform (juce::AffineTransform::scale (scale));
-
-                // cache at full opacity (later composited with the correct color/opacity)
-                g2.setColour (juce::Colours::white);
-
-                // we're still working @1x until fillPath happens
-                // blurContextBounds x/y is negative (relative to path @ 0,0) and we must render in positive space
-                // Note that offset isn't used here,
-                auto unscaledPosition = -scaledShadowBounds.getPosition().toFloat() / scale;
-
-                g2.fillPath (shadowPath, juce::AffineTransform::translation (unscaledPosition));
-
-                // perform the blur with the fastest algorithm available
-                melatonin::blur::singleChannel (renderedSingleChannel, (size_t) scaledRadius);
-
-                singleChannelRender = renderedSingleChannel;
-                return singleChannelRender;
-            }
+            juce::Image& render (juce::Path& originAgnosticPath, float scale, bool stroked = false);
 
             // Offset is added on the fly, it's not actually a part of the render
             // and can change without invalidating cache

--- a/melatonin/shadows.h
+++ b/melatonin/shadows.h
@@ -1,5 +1,4 @@
 #pragma once
-#include "implementations/gin.h"
 #include "internal/cached_shadows.h"
 #include "juce_gui_basics/juce_gui_basics.h"
 

--- a/melatonin_blur.cpp
+++ b/melatonin_blur.cpp
@@ -1,3 +1,8 @@
+#include "melatonin_blur.h"
+#include "melatonin/cached_blur.cpp"
+#include "melatonin/internal/cached_shadows.cpp"
+#include "melatonin/internal/rendered_single_channel_shadow.cpp"
+
 #if RUN_MELATONIN_TESTS
     #include "benchmarks/benchmarks.cpp"
     #include "tests/blur_implementations.cpp"

--- a/tests/blur_implementations.cpp
+++ b/tests/blur_implementations.cpp
@@ -7,6 +7,7 @@
 #include "../melatonin/implementations/naive_class.h"
 #include "../melatonin/implementations/naive_with_martin_optimization.h"
 #include "../melatonin/implementations/templated_function.h"
+#include "../melatonin/internal/implementations.h"
 
 // These require melatonin::vector, not in this repo
 // #include "../melatonin/implementations/templated_function_float.h"

--- a/tests/drop_shadow.cpp
+++ b/tests/drop_shadow.cpp
@@ -1,4 +1,5 @@
 #include "../melatonin/shadows.h"
+#include "../melatonin/internal/implementations.h"
 #include "helpers/pixel_helpers.h"
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>


### PR DESCRIPTION
So here's a better version of #45 (maybe see PR for the context).

This is what I've done:
- moved all definitions from `cached_shadows.h`, `cached_blur.h` and `rendered_single_channel_shadow.h` into corresponding .cpp files.
- moved the inclusion of the `implementations.h` into those .cpp files.
- explicitly included `implementations.h` in some of the test .cpp's so they could compile again.

The git history became a bit messy as I forgot to properly update the main branch in my repo before I started... so I suggest you squash and merge if you decide to accept it :)