### PR TITLE
Make it work on Android.

### DIFF
--- a/melatonin/internal/implementations.h
+++ b/melatonin/internal/implementations.h
@@ -29,7 +29,7 @@
     #else
         #include "../implementations/float_vector_stack_blur.h"
     #endif
-#elif JUCE_LINUX
+#elif JUCE_LINUX || JUCE_ANDROID
     #include "../implementations/float_vector_stack_blur.h"
 #else
   #error "Unsupported platform!"


### PR DESCRIPTION
I'm trying to get [AudiblePlanets](https://bedroomproducersblog.com/2024/04/13/audible-planets-modular-synth/) working on Android, but it fails to build at melatonin_blur due to "unsupported platform" error. It does compile on Android just as on Linux though, so at least I do not want to have it blocking the platform. AudiblePlanets now runs and shows the GUI. I'm not sure where it uses melatonin_blur though.