### PR TITLE
Add PathWithShadows

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,19 +7,19 @@ the [JUCE C++ framework](https://juce.com/).
 
 *Batteries-included* means it aims to give you everything out of the box:
 
-* 👩‍🎨 Figma/CSS-accurate drop and inner shadows on paths!
-* 🔠 Drop and Inner Text shadows!
-* 💅🏼 Supports both filled and stroked paths!
-* 🌇 ARGB image blurs!
-* 🚀 Fast! (see [benchmarks](#more-benchmarks)).
-* 🔎 Retina-friendly (context scale-aware)!
-* 🍰 Trivial to layer multiple shadows!
-* ⚙️ Behind-the-scenes multi-layer caching!
-* 😎 Debug optimized for high quality of life!
-* 🤖 Over 1000 correctness tests passing on mac/windows!
+* 👩‍🎨 Figma/CSS-accurate drop and inner shadows on paths
+* 🔠 Drop and Inner Text shadows
+* 💅🏼 Supports both filled and stroked paths
+* 🌇 ARGB image blurs
+* 🚀 Fast! (see [benchmarks](#more-benchmarks))
+* 🔎 Retina-friendly (context scale-aware)
+* 🍰 Trivial to layer multiple shadows
+* ⚙️ Behind-the-scenes multi-layer caching
+* 😎 Debug optimized for high quality of life
+* 🤖 Over 1000 correctness tests passing on macOS/windows
 * 🚂 Compatible down to macOS 10.13 (progressive speedups on recent versions)
 
-The goal: modern vector interfaces in JUCE (100s of shadows) without resorting to deprecated solutions with lower quality of life (looking at you, OpenGL on macOS!).
+The goal: modern vector interfaces in JUCE (100s of shadows) without having to resort to deprecated solutions with lower quality of life (looking at you, OpenGL on macOS!).
 
 https://github.com/sudara/melatonin_blur/assets/472/3e1d6c9a-aab9-422f-a262-6b63cbca5b71
 
@@ -121,17 +121,18 @@ Melatonin Blur comes with a test suite that verifies compatibility with design p
 You can specify the color, radius, offset and spread of each blur, passing them in a struct like so:
 
 ```cpp
+
 struct ShadowParameters
 {
     // one single color per shadow
-    const juce::Colour color = {};
-    const int radius = 1;
-    const juce::Point<int> offset = { 0, 0 };
+    juce::Colour color = juce::Colours::black;
+    int radius = 1;
+    juce::Point<int> offset = { 0, 0 };
 
-    // Spread literally just expands or contracts the path size
+    // Spread literally just expands or contracts the *path* size
     // Inverted for inner shadows
-    const int spread = 0;
-}
+    int spread = 0;
+};
 ```
 
 Or just as parameters, like so:
@@ -257,9 +258,9 @@ shadow.setSpread(10);
 
 ### Default Constructors for Inner/DropShadow
 
-Don't know your colors at compile time?
+Don't know your shadow's colors, sizes, etc at compile time?
 
-That's fine, there's a default constructor, you can update the color in the paint method.
+That's fine, there's a default constructor. You can have a class member such as `melatonin::DropShadow shadow` and call `.setColor` whenever it works for you.
 
 ### Stroked Paths
 
@@ -296,6 +297,13 @@ Right now, the API just mirrors `g.drawText`, so it's not particularly DRY. I'm 
 Just like `g.drawText`, you can pass in a `juce::Rectangle<int>`, `juce::Rectangle<float>`, or the `x, y, w, h` as bounds arguments.
 
 Text shadows are cached. As with path shadows, repainting is cheap and changing their color, offset, opacity is free. However, changing the font, text, justification or bounds will require re-rendering (both the glyphs and underlying blur).
+
+### pathWithShadow
+
+You can use `pathWithShadow` to combine a path and inner/drop shadows into a single object for rendering convenience. 
+
+```cpp
+
 
 ### Full Color Blurs
 

--- a/melatonin/internal/rendered_single_channel_shadow.h
+++ b/melatonin/internal/rendered_single_channel_shadow.h
@@ -10,7 +10,7 @@ namespace melatonin
     struct ShadowParameters
     {
         // one single color per shadow
-        juce::Colour color = {};
+        juce::Colour color = juce::Colours::black;
         int radius = 1;
         juce::Point<int> offset = { 0, 0 };
 
@@ -53,7 +53,7 @@ namespace melatonin
                     // expand the actual path itself
                     // note: this is 1x, it'll be upscaled as needed by fillPath
                     auto bounds = originAgnosticPath.getBounds().expanded (parameters.inner ? (float) -parameters.spread : (float) parameters.spread);
-                    shadowPath.scaleToFit (bounds.getX(), bounds.getY(), bounds.getWidth(), bounds.getHeight(), true);
+                    shadowPath.scaleToFit (bounds.getX(), bounds.getY(), bounds.getWidth(), bounds.getHeight(), false);
                 }
 
                 // inner shadows are rendered by inverting the path, drop shadowing and clipping to the original path

--- a/melatonin/shadows.h
+++ b/melatonin/shadows.h
@@ -18,22 +18,22 @@ namespace melatonin
         struct ShadowParameters
         {
             // one single color per shadow
-            const juce::Colour color = {};
-            const int radius = 1;
-            const juce::Point<int> offset = { 0, 0 };
+            juce::Colour color = {};
+            int radius = 1;
+            juce::Point<int> offset = { 0, 0 };
 
             // Spread literally just expands or contracts the *path* size
             // Inverted for inner shadows
-            const int spread = 0;
+            int spread = 0;
 
-            // by default we match the main graphics context's scaling factor
-            bool lowQuality = false;
-        }
+            // an inner shadow is just a modified drop shadow
+            bool inner = false;
+        };
     */
     class DropShadow : public internal::CachedShadows
     {
     public:
-        DropShadow() : DropShadow (juce::Colours::black, 0, { 0, 0 }, 0) {}
+        DropShadow() = default;
 
         // individual arguments
         DropShadow (juce::Colour color, int radius, juce::Point<int> offset = { 0, 0 }, int spread = 0)
@@ -45,6 +45,9 @@ namespace melatonin
 
         // multiple ShadowParameters
         DropShadow (std::initializer_list<ShadowParameters> p) : CachedShadows (p) {}
+
+        // multiple via a std::vector
+        DropShadow (const std::vector<ShadowParameters>& p) : CachedShadows (p) {}
     };
 
     // An inner shadow is basically the *inverted* filled path, blurred and clipped to the path
@@ -52,31 +55,75 @@ namespace melatonin
     class InnerShadow : public internal::CachedShadows
     {
     public:
-        InnerShadow() : InnerShadow (juce::Colours::black, 0, { 0, 0 }, 0) {}
-
-        // multiple shadows
-        InnerShadow (std::initializer_list<ShadowParameters> p) : CachedShadows (p, true) {}
-
-        // single initializer list
-        explicit InnerShadow (ShadowParameters p) : CachedShadows ({ p }, true) {}
+        InnerShadow() = default;
 
         // individual arguments
         InnerShadow (juce::Colour color, int radius, juce::Point<int> offset = { 0, 0 }, int spread = 0)
             : CachedShadows ({ { color, radius, offset, spread } }, true) {}
+
+        // single
+        explicit InnerShadow (ShadowParameters p) : CachedShadows ({ p }, true) {}
+
+        // multiple shadows
+        InnerShadow (std::initializer_list<ShadowParameters> p) : CachedShadows (p, true) {}
+
+        // multiple via a std::vector
+        InnerShadow (const std::vector<ShadowParameters>& p) : CachedShadows (p, true) {}
+
+    private:
+        ShadowParameters emptyShadow() override
+        {
+            auto empty = ShadowParameters {};
+            empty.inner = true;
+            return empty;
+        }
     };
 
-    // Renders a collection of inner and drop shadows plus a path
-    class PathWithShadows : public internal::CachedShadows
+    // Owns and renders a path plus a collection of inner and drop shadows
+    // great for buttons, modals, etc...
+    class PathWithShadows
     {
+    public:
+        juce::Path path;
+
+        PathWithShadows() = default;
+
         // multiple shadows
-        PathWithShadows (std::initializer_list<ShadowParameters> p) : CachedShadows (p) {}
+        PathWithShadows (std::initializer_list<ShadowParameters> p)
+        {
+            std::vector<ShadowParameters> innerParameters;
+            std::vector<ShadowParameters> dropParameters;
+            for (const auto& param : p)
+            {
+                if (param.inner)
+                {
+                    innerParameters.push_back (param);
+                }
+                else
+                {
+                    dropParameters.push_back (param);
+                }
+            }
 
-        // single ShadowParameters
-        // melatonin::DropShadow ({Colour::fromRGBA (255, 183, 43, 111), pulse (6)}).render (g, button);
-        explicit PathWithShadows (ShadowParameters p) : CachedShadows ({ p }) {}
+            dropShadow = DropShadow (dropParameters);
+            innerShadow = InnerShadow (innerParameters);
+        }
 
-        // individual arguments
-        PathWithShadows (juce::Colour color, int radius, juce::Point<int> offset = { 0, 0 }, int spread = 0)
-            : CachedShadows ({ { color, radius, offset, spread } }) {}
+        void render (juce::Graphics& g)
+        {
+            dropShadow.render (g, path);
+            g.fillPath (path);
+            innerShadow.render (g, path);
+        }
+
+        void render (juce::Graphics& g, const juce::PathStrokeType& strokeType)
+        {
+            dropShadow.render (g, path, strokeType);
+            g.strokePath (path, strokeType);
+            innerShadow.render (g, path, strokeType);
+        }
+
+        DropShadow dropShadow;
+        InnerShadow innerShadow;
     };
 }

--- a/melatonin_blur.cpp
+++ b/melatonin_blur.cpp
@@ -1,7 +1,11 @@
-#if RUN_MELATONIN_TESTS
+#if RUN_MELATONIN_BENCHMARKS
     #include "benchmarks/benchmarks.cpp"
+#endif
+
+#if RUN_MELATONIN_TESTS
     #include "tests/blur_implementations.cpp"
     #include "tests/drop_shadow.cpp"
     #include "tests/inner_shadow.cpp"
     #include "tests/shadow_scaling.cpp"
+    #include "tests/path_with_shadows.cpp"
 #endif

--- a/tests/path_with_shadows.cpp
+++ b/tests/path_with_shadows.cpp
@@ -1,0 +1,72 @@
+#include "../melatonin/shadows.h"
+#include "helpers/pixel_helpers.h"
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
+
+TEST_CASE ("Melatonin Blur PathWithShadows")
+{
+    // here's what our test image looks like:
+    // 0=white, 1=black, just to be annoying...
+
+    // 0  0  0  0  0  0  0  0  0
+    // 0  0  0  0  0  0  0  0  0
+    // 0  0  0  0  0  0  0  0  0
+    // 0  0  0  1  1  1  0  0  0
+    // 0  0  0  1  1  1  0  0  0
+    // 0  0  0  1  1  1  0  0  0
+    // 0  0  0  0  0  0  0  0  0
+    // 0  0  0  0  0  0  0  0  0
+    // 0  0  0  0  0  0  0  0  0
+
+    // create a 3px by 3px square
+    auto bounds = juce::Rectangle<float> (3, 3);
+
+    // needed for JUCE not to pee its pants (aka leak) when working with graphics
+    juce::ScopedJuceInitialiser_GUI juce;
+
+    juce::Image result (juce::Image::ARGB, 9, 9, true);
+    juce::Graphics g (result);
+    g.fillAll (juce::Colours::white);
+
+    melatonin::PathWithShadows p;
+
+    // stick the 3x3 box centered inside a 9x9
+    p.path.addRectangle (bounds.translated (3, 3));
+
+    SECTION ("renders the path")
+    {
+        p.render (g);
+        CHECK (filledBounds (result).toString() == juce::Rectangle<int> (3, 3, 3, 3).toString());
+    }
+
+    SECTION ("renders a 1px drop shadow")
+    {
+        p.dropShadow.setColor (juce::Colours::red).setRadius (1);
+        p.render (g);
+        CHECK (filledBounds (result).toString() == juce::Rectangle<int> (2, 2, 5, 5).toString());
+    }
+
+    SECTION ("path renders in front of drop shadow")
+    {
+        p.dropShadow.setColor (juce::Colours::red).setRadius (1);
+        p.render (g);
+
+        // check for the black square
+        CHECK (getPixels (result, 3, { 3, 5 }) == "FF000000, FF000000, FF000000");
+        CHECK (getPixels (result, { 3, 5 }, 3) == "FF000000, FF000000, FF000000");
+    }
+
+    SECTION ("1px inner shadow")
+    {
+        p.innerShadow.setColor (juce::Colours::red).setRadius (1);
+        p.render (g);
+
+        // still is 3x3
+        CHECK (filledBounds (result).toString() == juce::Rectangle<int> (3, 3, 3, 3).toString());
+
+        // outside edges of square replaced with red
+        CHECK (getPixels (result, 3, { 3, 5 }) == "FF700000, FF400000, FF700000");
+        CHECK (getPixels (result, { 3, 5 }, 3) == "FF700000, FF400000, FF700000");
+    }
+}


### PR DESCRIPTION
This PR does a few things:

* Adds the `PathWithShadows` helper
* Makes the setters like `setColor` chainable so you can do things like `shadow.setRadius(5).setOpacity(0.5f)`
* Fixes #59 
* Adds default constructors to Drop/InnerShadow