### PR TITLE
JUCE 8 Support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,8 +34,10 @@ jobs:
       fail-fast: false # show errors for each platform vs. cancel build
       matrix:
         os: [ macos-11, macos-12, macos-13, macos-14, windows-2022, windows-2019, ubuntu-latest ]
+        juce: [ 7, 8 ]
 
     steps:
+
       # Setup MSVC toolchain and developer command prompt (Windows)
       - uses: ilammy/msvc-dev-cmd@v1
         with:
@@ -55,7 +57,6 @@ jobs:
 
       - name: Install Ninja (Windows)
         if: runner.os == 'Windows'
-        shell: bash
         run: choco install ninja
 
       - name: Install macOS Deps
@@ -71,11 +72,26 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.4
 
       - name: Configure
-        shell: bash
-        run: cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache . -DCMAKE_SYSTEM_VERSION=10.0.22621.0
+        if: runner.os == 'Windows'
+        # D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR is a temporary workaround for a Visual Studio+GA snafu
+        # check if resolved here: https://github.com/sudara/pamplejuce/issues/103
+        run: | 
+          if [ ${{ matrix.juce }} -eq 8 ]; then
+            cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache . -DCMAKE_SYSTEM_VERSION=10.0.22621.0 -DCMAKE_CXX_FLAGS=" /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR -DJUCE8=ON"
+          else
+            cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache . -DCMAKE_SYSTEM_VERSION=10.0.22621.0 -DCMAKE_CXX_FLAGS=" /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR"
+          fi
+
+      - name: Configure
+        if: runner.os != 'Windows'
+        run: |
+          if [ ${{ matrix.juce }} -eq 8 ]; then
+            cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache . -DJUCE8=ON
+          else 
+            cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache .
+          fi
 
       - name: Build
-        shell: bash
         run: cmake --build ${{ env.BUILD_DIR }} --config ${{ env.BUILD_TYPE }} --parallel 4
 
       - name: Tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
 
       # This block can be removed once 15.1 is default (JUCE requires it when building on macOS 14)
       - name: Use latest Xcode on system (macOS)
-        if: ${{ matrix.name == 'macOS' }}
+        if: ${{ runner.os == 'macOS' }}
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,8 +76,8 @@ jobs:
         # D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR is a temporary workaround for a Visual Studio+GA snafu
         # check if resolved here: https://github.com/sudara/pamplejuce/issues/103
         run: | 
-          if [ "${{ matrix.juce }}" == "JUCE8" ]; then
-            cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache . -DCMAKE_SYSTEM_VERSION=10.0.22621.0 -DCMAKE_CXX_FLAGS=" /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR -DJUCE8=ON"
+          if [ "${{ matrix.juce }}" == "JUCE7" ]; then
+            cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache . -DCMAKE_SYSTEM_VERSION=10.0.22621.0 -DCMAKE_CXX_FLAGS=" /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR -DJUCE7=ON"
           else
             cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache . -DCMAKE_SYSTEM_VERSION=10.0.22621.0 -DCMAKE_CXX_FLAGS=" /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR"
           fi
@@ -85,8 +85,8 @@ jobs:
       - name: Configure
         if: runner.os != 'Windows'
         run: |
-          if [ "${{ matrix.juce }}" == "JUCE8" ]; then
-            cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache . -DJUCE8=ON
+          if [ "${{ matrix.juce }}" == "JUCE7" ]; then
+            cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache . -DJUCE7=ON
           else 
             cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache .
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: Tests
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: 20 # macos-11 in particular needs more than 15 min
 
     strategy:
       fail-fast: false # show errors for each platform vs. cancel build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,9 @@ jobs:
     steps:
       # Setup MSVC toolchain and developer command prompt (Windows)
       - uses: ilammy/msvc-dev-cmd@v1
-      
+        with:
+          sdk: 10.0.22621.0
+
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,6 +78,10 @@ jobs:
         shell: bash
         run: cmake --build ${{ env.BUILD_DIR }} --config ${{ env.BUILD_TYPE }} --parallel 4
 
-      - name: Test
+      - name: Tests
         working-directory: ${{ env.BUILD_DIR }}
-        run: ctest --output-on-failure -j4 -VV
+        run: ./Tests
+
+      - name: Benchmarks
+        working-directory: ${{ env.BUILD_DIR }}
+        run: ./Benchmarks

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Configure
         shell: bash
-        run: cmake -B ${{ env.BUILD_DIR }} -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache . -DCMAKE_SYSTEM_VERSION=10.0.22621.0
+        run: cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache . -DCMAKE_SYSTEM_VERSION=10.0.22621.0
 
       - name: Build
         shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,13 @@ jobs:
         with:
           sdk: 10.0.22621.0
 
+      # This block can be removed once 15.1 is default (JUCE requires it when building on macOS 14)
+      - name: Use latest Xcode on system (macOS)
+        if: ${{ matrix.name == 'macOS' }}
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -65,7 +72,7 @@ jobs:
 
       - name: Configure
         shell: bash
-        run: cmake -B ${{ env.BUILD_DIR }} -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache .
+        run: cmake -B ${{ env.BUILD_DIR }} -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache . -DCMAKE_SYSTEM_VERSION=10.0.22621.0
 
       - name: Build
         shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false # show errors for each platform vs. cancel build
       matrix:
         os: [ macos-11, macos-12, macos-13, macos-14, windows-2022, windows-2019, ubuntu-latest ]
-        juce: [ 7, 8 ]
+        juce: [ JUCE7, JUCE8 ]
 
     steps:
 
@@ -76,7 +76,7 @@ jobs:
         # D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR is a temporary workaround for a Visual Studio+GA snafu
         # check if resolved here: https://github.com/sudara/pamplejuce/issues/103
         run: | 
-          if [ ${{ matrix.juce }} -eq 8 ]; then
+          if [ ${{ matrix.juce }} -eq JUCE8 ]; then
             cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache . -DCMAKE_SYSTEM_VERSION=10.0.22621.0 -DCMAKE_CXX_FLAGS=" /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR -DJUCE8=ON"
           else
             cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache . -DCMAKE_SYSTEM_VERSION=10.0.22621.0 -DCMAKE_CXX_FLAGS=" /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR"
@@ -85,7 +85,7 @@ jobs:
       - name: Configure
         if: runner.os != 'Windows'
         run: |
-          if [ ${{ matrix.juce }} -eq 8 ]; then
+          if [ ${{ matrix.juce }} -eq JUCE8 ]; then
             cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache . -DJUCE8=ON
           else 
             cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,9 @@ jobs:
         os: [ macos-11, macos-12, macos-13, macos-14, windows-2022, windows-2019, ubuntu-latest ]
 
     steps:
+      # Setup MSVC toolchain and developer command prompt (Windows)
+      - uses: ilammy/msvc-dev-cmd@v1
+      
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,6 @@ on:
 env:
   BUILD_TYPE: Release
   BUILD_DIR: Builds
-  CMAKE_BUILD_PARALLEL_LEVEL: 3 # Use up to 3 cpus to build juceaide, etc
   HOMEBREW_NO_INSTALL_CLEANUP: 1
   SCCACHE_GHA_ENABLED: "true"
 
@@ -26,6 +25,7 @@ permissions:
 jobs:
 
   BuildAndTest:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: Tests
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,7 +76,7 @@ jobs:
         # D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR is a temporary workaround for a Visual Studio+GA snafu
         # check if resolved here: https://github.com/sudara/pamplejuce/issues/103
         run: | 
-          if [ ${{ matrix.juce }} -eq JUCE8 ]; then
+          if [ "${{ matrix.juce }}" == "JUCE8" ]; then
             cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache . -DCMAKE_SYSTEM_VERSION=10.0.22621.0 -DCMAKE_CXX_FLAGS=" /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR -DJUCE8=ON"
           else
             cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache . -DCMAKE_SYSTEM_VERSION=10.0.22621.0 -DCMAKE_CXX_FLAGS=" /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR"
@@ -85,7 +85,7 @@ jobs:
       - name: Configure
         if: runner.os != 'Windows'
         run: |
-          if [ ${{ matrix.juce }} -eq JUCE8 ]; then
+          if [ "${{ matrix.juce }}" == "JUCE8" ]; then
             cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache . -DJUCE8=ON
           else 
             cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false # show errors for each platform vs. cancel build
       matrix:
-        os: [ macos-11, macos-12, macos-13, macos-14, windows-latest, ubuntu-latest ]
+        os: [ macos-11, macos-12, macos-13, macos-14, windows-2022, windows-2019, ubuntu-latest ]
 
     steps:
       - name: Checkout
@@ -54,11 +54,6 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update && sudo apt install libasound2-dev libx11-dev libxinerama-dev libxext-dev libfreetype6-dev libwebkit2gtk-4.0-dev libglu1-mesa-dev ninja-build
-          # downgrade gcc to workaround 22.04 and C++20 issue
-          # see: https://github.com/actions/runner-images/issues/8659
-          sudo rm -f /etc/apt/sources.list.d/ubuntu-toolchain-r-ubuntu-test-jammy.list
-          sudo apt-get update
-          sudo apt-get install -y --allow-downgrades libc6=2.35-0ubuntu3.7 libc6-dev=2.35-0ubuntu3.7 libstdc++6=12.3.0-1ubuntu1~22.04 libgcc-s1=12.3.0-1ubuntu1~22.04
 
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,19 +12,20 @@ if (MelatoninBlur_IS_TOP_LEVEL)
     option(JUCE_7 "Run tests on JUCE 7" OFF)
 
     message(STATUS "Cloning JUCE...")
-    if(JUCE_7)
-    FetchContent_Declare(JUCE
-            GIT_REPOSITORY https://github.com/juce-framework/JUCE.git
-            GIT_TAG juce8
-            GIT_PROGRESS TRUE
-    )
-    else()
-    FetchContent_Declare(JUCE
-            GIT_REPOSITORY
-            GIT_TAG 7.0.12
-            GIT_PROGRESS TRUE
-    )
-    endif()
+    if (JUCE_7)
+        FetchContent_Declare(JUCE
+                GIT_REPOSITORY
+                GIT_TAG 7.0.12
+                GIT_PROGRESS TRUE
+        )
+    else ()
+
+        FetchContent_Declare(JUCE
+                GIT_REPOSITORY https://github.com/juce-framework/JUCE.git
+                GIT_TAG develop
+                GIT_PROGRESS TRUE
+        )
+    endif ()
 
     FetchContent_MakeAvailable(JUCE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if (MelatoninBlur_IS_TOP_LEVEL)
 
     FetchContent_Declare(JUCE
         GIT_REPOSITORY https://github.com/juce-framework/JUCE.git
-        GIT_TAG 7.0.8
+        GIT_TAG juce8
         GIT_PROGRESS TRUE
     )
     FetchContent_MakeAvailable(JUCE)
@@ -22,7 +22,7 @@ if (MelatoninBlur_IS_TOP_LEVEL)
         GIT_REPOSITORY https://github.com/catchorg/Catch2.git
         GIT_PROGRESS TRUE
         GIT_SHALLOW TRUE
-        GIT_TAG v3.4.0)
+        GIT_TAG v3.6.0)
     FetchContent_MakeAvailable(Catch2) # find_package equivalent
 
     enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,13 +9,23 @@ set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 include(FetchContent)
 if (MelatoninBlur_IS_TOP_LEVEL)
-    message(STATUS "Cloning JUCE...")
+    option(JUCE_8 "Run tests on JUCE8" ON)
 
+    message(STATUS "Cloning JUCE...")
+    if(JUCE_8)
     FetchContent_Declare(JUCE
             GIT_REPOSITORY https://github.com/juce-framework/JUCE.git
             GIT_TAG juce8
             GIT_PROGRESS TRUE
     )
+    else()
+    FetchContent_Declare(JUCE
+            GIT_REPOSITORY
+            GIT_TAG 7.0.12
+            GIT_PROGRESS TRUE
+    )
+    endif()
+
     FetchContent_MakeAvailable(JUCE)
 
     FetchContent_Declare(Catch2
@@ -88,12 +98,6 @@ if (MelatoninBlur_IS_TOP_LEVEL)
         # https://stackoverflow.com/q/45685487
         target_compile_options(Benchmarks PUBLIC $<$<CONFIG:RELEASE>:-Ofast>)
         target_compile_options(Benchmarks PUBLIC $<$<CONFIG:RelWithDebInfo>:-Ofast>)
-    endif ()
-
-    # Temporary workaround for https://github.com/actions/runner-images/issues/10020
-    if (MSVC)
-        target_compile_options(Tests PUBLIC /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
-        target_compile_options(Benchmarks PUBLIC /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
     endif ()
 
 else ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,12 @@ if (MelatoninBlur_IS_TOP_LEVEL)
         JUCE_USE_CURL=0
     )
 
+    # Temporary workaround for https://github.com/actions/runner-images/issues/10020
+    if(MSVC)
+        target_compile_options(Tests PRIVATE /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
+        target_compile_options(Benchmarks PRIVATE /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
+    endif()
+
     include(${Catch2_SOURCE_DIR}/extras/Catch.cmake)
     catch_discover_tests(Tests)
     catch_discover_tests(Benchmarks)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,10 +9,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 include(FetchContent)
 if (MelatoninBlur_IS_TOP_LEVEL)
-    option(JUCE_8 "Run tests on JUCE8" ON)
+    option(JUCE_7 "Run tests on JUCE 7" OFF)
 
     message(STATUS "Cloning JUCE...")
-    if(JUCE_8)
+    if(JUCE_7)
     FetchContent_Declare(JUCE
             GIT_REPOSITORY https://github.com/juce-framework/JUCE.git
             GIT_TAG juce8

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.20)
 
 project(MelatoninBlur VERSION 1.0.0 LANGUAGES CXX
-    DESCRIPTION "Fast Blurs for JUCE"
-    HOMEPAGE_URL "https://github.com/sudara/melatonin_blur")
+        DESCRIPTION "Fast Blurs for JUCE"
+        HOMEPAGE_URL "https://github.com/sudara/melatonin_blur")
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
@@ -12,17 +12,17 @@ if (MelatoninBlur_IS_TOP_LEVEL)
     message(STATUS "Cloning JUCE...")
 
     FetchContent_Declare(JUCE
-        GIT_REPOSITORY https://github.com/juce-framework/JUCE.git
-        GIT_TAG juce8
-        GIT_PROGRESS TRUE
+            GIT_REPOSITORY https://github.com/juce-framework/JUCE.git
+            GIT_TAG juce8
+            GIT_PROGRESS TRUE
     )
     FetchContent_MakeAvailable(JUCE)
 
     FetchContent_Declare(Catch2
-        GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-        GIT_PROGRESS TRUE
-        GIT_SHALLOW TRUE
-        GIT_TAG v3.6.0)
+            GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+            GIT_PROGRESS TRUE
+            GIT_SHALLOW TRUE
+            GIT_TAG v3.6.0)
     FetchContent_MakeAvailable(Catch2) # find_package equivalent
 
     enable_testing()
@@ -42,45 +42,39 @@ if (MelatoninBlur_IS_TOP_LEVEL)
     juce_add_module("${CMAKE_CURRENT_SOURCE_DIR}")
 
     target_link_libraries(Tests PRIVATE
-        melatonin_blur
-        Catch2::Catch2WithMain
-        juce::juce_graphics # Image, etc
-        juce::juce_gui_basics # Colour, etc
-        juce::juce_audio_basics # FloatVectorOperations
-        juce::juce_recommended_config_flags
-        juce::juce_recommended_lto_flags
-        juce::juce_recommended_warning_flags)
+            melatonin_blur
+            Catch2::Catch2WithMain
+            juce::juce_graphics # Image, etc
+            juce::juce_gui_basics # Colour, etc
+            juce::juce_audio_basics # FloatVectorOperations
+            juce::juce_recommended_config_flags
+            juce::juce_recommended_lto_flags
+            juce::juce_recommended_warning_flags)
 
     target_link_libraries(Benchmarks PRIVATE
-        melatonin_blur
-        Catch2::Catch2WithMain
-        juce::juce_graphics # Image, etc
-        juce::juce_gui_basics # Colour, etc
-        juce::juce_audio_basics # FloatVectorOperations
-        juce::juce_recommended_config_flags
-        juce::juce_recommended_lto_flags
-        juce::juce_recommended_warning_flags)
+            melatonin_blur
+            Catch2::Catch2WithMain
+            juce::juce_graphics # Image, etc
+            juce::juce_gui_basics # Colour, etc
+            juce::juce_audio_basics # FloatVectorOperations
+            juce::juce_recommended_config_flags
+            juce::juce_recommended_lto_flags
+            juce::juce_recommended_warning_flags)
 
     # Enable this once tests are happy fundamentally in CI
-    # set_target_properties("${TARGET_NAME}" PROPERTIES COMPILE_WARNING_AS_ERROR ON)
+    # set_target_properties(Tests PROPERTIES COMPILE_WARNING_AS_ERROR ON)
 
     target_compile_definitions(Tests PRIVATE
-        PROJECT_ROOT="${CMAKE_SOURCE_DIR}"
-        JUCE_WEB_BROWSER=0
-        JUCE_USE_CURL=0
+            PROJECT_ROOT="${CMAKE_SOURCE_DIR}"
+            JUCE_WEB_BROWSER=0
+            JUCE_USE_CURL=0
     )
 
     target_compile_definitions(Benchmarks PRIVATE
-        PROJECT_ROOT="${CMAKE_SOURCE_DIR}"
-        JUCE_WEB_BROWSER=0
-        JUCE_USE_CURL=0
+            PROJECT_ROOT="${CMAKE_SOURCE_DIR}"
+            JUCE_WEB_BROWSER=0
+            JUCE_USE_CURL=0
     )
-
-    # Temporary workaround for https://github.com/actions/runner-images/issues/10020
-    if(MSVC)
-        target_compile_options(Tests PRIVATE /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
-        target_compile_options(Benchmarks PRIVATE /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
-    endif()
 
     include(${Catch2_SOURCE_DIR}/extras/Catch.cmake)
     catch_discover_tests(Tests)
@@ -95,6 +89,13 @@ if (MelatoninBlur_IS_TOP_LEVEL)
         target_compile_options(Benchmarks PUBLIC $<$<CONFIG:RELEASE>:-Ofast>)
         target_compile_options(Benchmarks PUBLIC $<$<CONFIG:RelWithDebInfo>:-Ofast>)
     endif ()
+
+    # Temporary workaround for https://github.com/actions/runner-images/issues/10020
+    if (MSVC)
+        target_compile_options(Tests PUBLIC /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
+        target_compile_options(Benchmarks PUBLIC /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
+    endif ()
+
 else ()
     if (NOT COMMAND juce_add_module)
         message(FATAL_ERROR "JUCE must be added to your project before melatonin_blur!")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ if (MelatoninBlur_IS_TOP_LEVEL)
             juce::juce_recommended_warning_flags)
 
     # Enable this once tests are happy fundamentally in CI
-    # set_target_properties(Tests PROPERTIES COMPILE_WARNING_AS_ERROR ON)
+    set_target_properties(Tests PROPERTIES COMPILE_WARNING_AS_ERROR ON)
 
     target_compile_definitions(Tests PRIVATE
             PROJECT_ROOT="${CMAKE_SOURCE_DIR}"

--- a/melatonin/blur_demo_component.h
+++ b/melatonin/blur_demo_component.h
@@ -148,14 +148,14 @@ namespace melatonin
             strokedInnerShadow.render (g, strokedInnerPath, juce::PathStrokeType (6));
 
             g.setColour (juce::Colours::white);
-            g.setFont (juce::Font (50).boldened());
+            g.setFont (g.getCurrentFont().withHeight (50).boldened());
             textDropShadow.render (g, "drop", textBounds, juce::Justification::left);
             g.drawText ("drop", textBounds, juce::Justification::left);
 
             g.drawText ("inner", textBounds, juce::Justification::centredRight);
             textInnerShadow.render (g, "inner", textBounds.toFloat(), juce::Justification::centredRight);
 
-            g.setFont (juce::Font (16));
+            g.setFont (16);
             auto labels = juce::StringArray ("radius", "spread", "offsetX", "offsetY", "opacity");
             for (auto i = 0; i < labels.size(); ++i)
             {
@@ -164,7 +164,7 @@ namespace melatonin
             auto elapsed = juce::Time::getMillisecondCounterHiRes() - start;
 
             g.setColour (juce::Colours::white);
-            g.setFont (juce::Font (16));
+            g.setFont (20);
             g.drawText ("rendered in " + juce::String (elapsed, 3) + "ms", getLocalBounds().removeFromTop (50), juce::Justification::centred);
         }
 
@@ -276,7 +276,11 @@ namespace melatonin
         }
 
     private:
+        #if JUCE_MAJOR_VERSION >= 8
+        juce::Font font = juce::FontOptions {}.withName("Arial").withHeight (110.f).withStyle ("bold");
+        #else
         juce::Font font { "Arial", 110.f, juce::Font::bold };
+        #endif
         melatonin::DropShadow dropShadow {
             { juce::Colour::fromRGB (196, 181, 157), 12, { 0, 13 } },
             { juce::Colours::white, 1, { 0, -2 } }

--- a/melatonin/blur_demo_component.h
+++ b/melatonin/blur_demo_component.h
@@ -276,7 +276,7 @@ namespace melatonin
         }
 
     private:
-        juce::Font font { "Arial Black", 110.f, 0 };
+        juce::Font font { "Arial", 110.f, juce::Font::bold };
         melatonin::DropShadow dropShadow {
             { juce::Colour::fromRGB (196, 181, 157), 12, { 0, 13 } },
             { juce::Colours::white, 1, { 0, -2 } }

--- a/melatonin/implementations/gin.h
+++ b/melatonin/implementations/gin.h
@@ -212,7 +212,7 @@ namespace melatonin::stackBlur
         }
     }
 
-    static void ginARGB (juce::Image& img, unsigned int radius)
+    [[maybe_unused]] static void ginARGB (juce::Image& img, unsigned int radius)
     {
         const unsigned int w = (unsigned int) img.getWidth();
         const unsigned int h = (unsigned int) img.getHeight();

--- a/melatonin/internal/cached_shadows.h
+++ b/melatonin/internal/cached_shadows.h
@@ -13,7 +13,6 @@ namespace melatonin::internal
         explicit CachedShadows (const std::vector<ShadowParameters>& shadowParameters, bool force_inner = false);
 
     public:
-        virtual ~CachedShadows() = default;
 
         // store a copy of the path to compare against for caching
         // public for testability, sorry not sorry

--- a/melatonin/internal/cached_shadows.h
+++ b/melatonin/internal/cached_shadows.h
@@ -62,9 +62,13 @@ namespace melatonin::internal
 
         struct TextArrangement
         {
-            juce::String text = {};
-            juce::Font font = {};
-            juce::Rectangle<float> area = {};
+            juce::String text;
+            #if JUCE_MAJOR_VERSION >= 8
+            juce::Font font = juce::FontOptions {};
+            #else
+            juce::Font font;
+            #endif
+            juce::Rectangle<float> area;
             juce::Justification justification = juce::Justification::left;
 
             bool operator== (const TextArrangement& other) const;

--- a/melatonin/internal/implementations.h
+++ b/melatonin/internal/implementations.h
@@ -72,7 +72,7 @@ namespace melatonin::internal
 // Don't use these directly, use melatonin::CachedBlur!
 namespace melatonin::blur
 {
-    static void singleChannel (juce::Image& img, size_t radius)
+    [[maybe_unused]] static void singleChannel (juce::Image& img, size_t radius)
     {
 #if MELATONIN_BLUR_VIMAGE
         if (internal::vImageSingleChannelAvailable())
@@ -86,7 +86,7 @@ namespace melatonin::blur
 #endif
     }
 
-    static void argb ([[maybe_unused]] juce::Image& srcImage, juce::Image& dstImage, size_t radius)
+    [[maybe_unused]] static void argb ([[maybe_unused]] juce::Image& srcImage, juce::Image& dstImage, size_t radius)
     {
 #if MELATONIN_BLUR_VIMAGE_MACOS14
         if (internal::vImageARGBAvailable())

--- a/melatonin/internal/implementations.h
+++ b/melatonin/internal/implementations.h
@@ -82,7 +82,7 @@ namespace melatonin::blur
 #elif defined(MELATONIN_BLUR_IPP)
         ippVectorSingleChannel (img, radius);
 #else
-        melatonin::blur::juceFloatVectorSingleChannel (img, static_cast<int>(radius));
+        melatonin::blur::juceFloatVectorSingleChannel (img, radius);
 #endif
     }
 

--- a/melatonin/internal/rendered_single_channel_shadow.cpp
+++ b/melatonin/internal/rendered_single_channel_shadow.cpp
@@ -41,23 +41,23 @@ namespace melatonin::internal
 
         // each shadow is its own single channel image associated with a color
         juce::Image renderedSingleChannel (juce::Image::SingleChannel, scaledShadowBounds.getWidth(), scaledShadowBounds.getHeight(), true);
+        {
+            // boot up a graphics context to give us access to fillPath, etc
+            juce::Graphics g2 (renderedSingleChannel);
 
-        // boot up a graphics context to give us access to fillPath, etc
-        juce::Graphics g2 (renderedSingleChannel);
+            // ensure we're working at the correct scale
+            g2.addTransform (juce::AffineTransform::scale (scale));
 
-        // ensure we're working at the correct scale
-        g2.addTransform (juce::AffineTransform::scale (scale));
+            // cache at full opacity (later composited with the correct color/opacity)
+            g2.setColour (juce::Colours::white);
 
-        // cache at full opacity (later composited with the correct color/opacity)
-        g2.setColour (juce::Colours::white);
+            // we're still working @1x until fillPath happens
+            // blurContextBounds x/y is negative (relative to path @ 0,0) and we must render in positive space
+            // Note that offset isn't used here,
+            auto unscaledPosition = -scaledShadowBounds.getPosition().toFloat() / scale;
 
-        // we're still working @1x until fillPath happens
-        // blurContextBounds x/y is negative (relative to path @ 0,0) and we must render in positive space
-        // Note that offset isn't used here,
-        auto unscaledPosition = -scaledShadowBounds.getPosition().toFloat() / scale;
-
-        g2.fillPath (shadowPath, juce::AffineTransform::translation (unscaledPosition));
-
+            g2.fillPath (shadowPath, juce::AffineTransform::translation (unscaledPosition));
+        }
         // perform the blur with the fastest algorithm available
         melatonin::blur::singleChannel (renderedSingleChannel, (size_t) scaledRadius);
 

--- a/melatonin_blur.cpp
+++ b/melatonin_blur.cpp
@@ -13,4 +13,5 @@
     #include "tests/inner_shadow.cpp"
     #include "tests/shadow_scaling.cpp"
     #include "tests/path_with_shadows.cpp"
+    #include "tests/text_shadow.cpp"
 #endif

--- a/tests/blur_implementations.cpp
+++ b/tests/blur_implementations.cpp
@@ -1,12 +1,10 @@
-#pragma once
-
-#include "../melatonin/implementations/dequeue.h"
+// #include "../melatonin/implementations/dequeue.h"
 #include "../melatonin/implementations/float_vector_stack_blur.h"
 #include "../melatonin/implementations/gin.h"
-#include "../melatonin/implementations/naive.h"
-#include "../melatonin/implementations/naive_class.h"
-#include "../melatonin/implementations/naive_with_martin_optimization.h"
-#include "../melatonin/implementations/templated_function.h"
+// #include "../melatonin/implementations/naive.h"
+// #include "../melatonin/implementations/naive_class.h"
+// #include "../melatonin/implementations/naive_with_martin_optimization.h"
+// #include "../melatonin/implementations/templated_function.h"
 #include "../melatonin/internal/implementations.h"
 
 // These require melatonin::vector, not in this repo
@@ -26,31 +24,31 @@
 // Keeps the actual tests DRY
 // bit ugly to wrap everything in std::function
 // it's because our stack blur is a class, not free func
-using BlurFunction = std::function<void (juce::Image&, int)>;
+using BlurFunction = std::function<void (juce::Image&, size_t)>;
 inline auto singleColorBlurImplementation()
 {
     return GENERATE (
-        std::make_pair ("gin", BlurFunction { [] (juce::Image& img, int radius) { melatonin::stackBlur::ginSingleChannel (img, radius); } }),
+        std::make_pair ("gin", BlurFunction { [] (juce::Image& img, size_t radius) { melatonin::stackBlur::ginSingleChannel (img, (unsigned int) radius); } }),
         // std::make_pair ("prefix sum naive", BlurFunction { [] (juce::Image& img, int radius) { melatonin::blur::prefixSumSingleChannel (img, radius); } }),
-        //std::make_pair ("dequeue", BlurFunction { [] (juce::Image& img, int radius) { melatonin::stackBlur::dequeueSingleChannel (img, radius); } }),
-        //std::make_pair ("circularBuffer", BlurFunction { [] (juce::Image& img, int radius) { melatonin::stackBlur::circularBufferSingleChannel (img, radius); } }),
-        //std::make_pair ("martin optimization", BlurFunction { [] (juce::Image& img, int radius) { melatonin::stackBlur::martinOptimizationSingleChannel (img, radius); } }),
+        // std::make_pair ("dequeue", BlurFunction { [] (juce::Image& img, int radius) { melatonin::stackBlur::dequeueSingleChannel (img, radius); } }),
+        // std::make_pair ("circularBuffer", BlurFunction { [] (juce::Image& img, int radius) { melatonin::stackBlur::circularBufferSingleChannel (img, radius); } }),
+        // std::make_pair ("martin optimization", BlurFunction { [] (juce::Image& img, int radius) { melatonin::stackBlur::martinOptimizationSingleChannel (img, radius); } }),
         //    std::make_pair ("vector", BlurFunction { [] (juce::Image& img, int radius) { melatonin::stackBlur::vectorSingleChannel (img, radius); } }),
         //    std::make_pair ("vector optimized", BlurFunction { [] (juce::Image& img, int radius) { melatonin::stackBlur::vectorOptimizedSingleChannel (img, radius); } }),
         //    std::make_pair ("vector class", BlurFunction { [&] (juce::Image& img, int radius) { melatonin::VectorStackBlur stackBlur (img, radius); } }),
-        std::make_pair ("juce's FloatVectorOperations", BlurFunction { [&] (juce::Image& img, int radius) { melatonin::blur::juceFloatVectorSingleChannel (img, radius); } }),
-        //std::make_pair ("naive class", BlurFunction { [&] (juce::Image& img, int radius) { melatonin::NaiveStackBlur stackBlur (img, radius); } }),
-        //std::make_pair ("templated function", BlurFunction { [&] (juce::Image& img, int radius) { melatonin::stackBlur::singleChannelTemplated (img, radius); } }),
-        //        std::make_pair ("templated function float", BlurFunction { [&] (juce::Image& img, int radius) { melatonin::stackBlur::templatedFloatSingleChannel (img, radius); } }),
-        std::make_pair ("Melatonin", BlurFunction { [&] (juce::Image& img, int radius) { melatonin::blur::singleChannel (img, radius); } }));
+        std::make_pair ("juce's FloatVectorOperations", BlurFunction { [&] (juce::Image& img, size_t radius) { melatonin::blur::juceFloatVectorSingleChannel (img, radius); } }),
+        // std::make_pair ("naive class", BlurFunction { [&] (juce::Image& img, int radius) { melatonin::NaiveStackBlur stackBlur (img, radius); } }),
+        // std::make_pair ("templated function", BlurFunction { [&] (juce::Image& img, int radius) { melatonin::stackBlur::singleChannelTemplated (img, radius); } }),
+        //         std::make_pair ("templated function float", BlurFunction { [&] (juce::Image& img, int radius) { melatonin::stackBlur::templatedFloatSingleChannel (img, radius); } }),
+        std::make_pair ("Melatonin", BlurFunction { [&] (juce::Image& img, size_t radius) { melatonin::blur::singleChannel (img, radius); } }));
 }
 
 inline auto rgbaBlurImplementation()
 {
     return GENERATE (
-        std::make_pair ("gin", BlurFunction { [] (juce::Image& img, int radius) { melatonin::stackBlur::ginARGB (img, radius); } }),
-        std::make_pair ("juce's FloatVectorOperations", BlurFunction { [&] (juce::Image& img, int radius) { melatonin::blur::juceFloatVectorARGB (img, radius); } }),
-        std::make_pair ("Melatonin", BlurFunction { [&] (juce::Image& img, int radius) {
+        std::make_pair ("gin", BlurFunction { [] (juce::Image& img, size_t radius) { melatonin::stackBlur::ginARGB (img, (unsigned int) radius); } }),
+        std::make_pair ("juce's FloatVectorOperations", BlurFunction { [&] (juce::Image& img, size_t radius) { melatonin::blur::juceFloatVectorARGB (img, radius); } }),
+        std::make_pair ("Melatonin", BlurFunction { [&] (juce::Image& img, size_t radius) {
             // argb goes haywire in-place, so we need to copy
             auto src = img.createCopy();
             melatonin::blur::argb (src, img, radius);
@@ -165,7 +163,6 @@ TEST_CASE ("Melatonin Blur")
 
         SECTION ("center 2 bright has symmetrical result")
         {
-
             const auto& [name, blur] = singleColorBlurImplementation();
 
             {
@@ -526,9 +523,9 @@ TEST_CASE ("Melatonin Blur")
                         std::vector<float> pixel = { 0.0f, 0.0f, 0.0f, 1.0f };
 
                         // modify just one channel of the pixel
-                        pixel[i] = 1.0f;
+                        pixel[(size_t) i] = 1.0f;
 
-                        std::vector<float> expected (image.getWidth());
+                        std::vector<float> expected ((size_t) image.getWidth());
 
                         {
                             juce::Image::BitmapData data (image, juce::Image::BitmapData::readWrite);
@@ -539,7 +536,7 @@ TEST_CASE ("Melatonin Blur")
                                 // yeah, this is sort of a mindfuck, going from BGRA -> RGBA
                                 auto pixelColor = juce::Colour::fromFloatRGBA (pixel[2], pixel[1], pixel[0], pixel[3]);
                                 data.setPixelColour (x, 0, pixelColor);
-                                expected[x] = pixel[i];
+                                expected[(size_t) x] = pixel[(size_t) i];
                             }
                         }
 

--- a/tests/blur_implementations.cpp
+++ b/tests/blur_implementations.cpp
@@ -32,15 +32,15 @@ inline auto singleColorBlurImplementation()
     return GENERATE (
         std::make_pair ("gin", BlurFunction { [] (juce::Image& img, int radius) { melatonin::stackBlur::ginSingleChannel (img, radius); } }),
         // std::make_pair ("prefix sum naive", BlurFunction { [] (juce::Image& img, int radius) { melatonin::blur::prefixSumSingleChannel (img, radius); } }),
-        std::make_pair ("dequeue", BlurFunction { [] (juce::Image& img, int radius) { melatonin::stackBlur::dequeueSingleChannel (img, radius); } }),
-        std::make_pair ("circularBuffer", BlurFunction { [] (juce::Image& img, int radius) { melatonin::stackBlur::circularBufferSingleChannel (img, radius); } }),
-        std::make_pair ("martin optimization", BlurFunction { [] (juce::Image& img, int radius) { melatonin::stackBlur::martinOptimizationSingleChannel (img, radius); } }),
+        //std::make_pair ("dequeue", BlurFunction { [] (juce::Image& img, int radius) { melatonin::stackBlur::dequeueSingleChannel (img, radius); } }),
+        //std::make_pair ("circularBuffer", BlurFunction { [] (juce::Image& img, int radius) { melatonin::stackBlur::circularBufferSingleChannel (img, radius); } }),
+        //std::make_pair ("martin optimization", BlurFunction { [] (juce::Image& img, int radius) { melatonin::stackBlur::martinOptimizationSingleChannel (img, radius); } }),
         //    std::make_pair ("vector", BlurFunction { [] (juce::Image& img, int radius) { melatonin::stackBlur::vectorSingleChannel (img, radius); } }),
         //    std::make_pair ("vector optimized", BlurFunction { [] (juce::Image& img, int radius) { melatonin::stackBlur::vectorOptimizedSingleChannel (img, radius); } }),
         //    std::make_pair ("vector class", BlurFunction { [&] (juce::Image& img, int radius) { melatonin::VectorStackBlur stackBlur (img, radius); } }),
         std::make_pair ("juce's FloatVectorOperations", BlurFunction { [&] (juce::Image& img, int radius) { melatonin::blur::juceFloatVectorSingleChannel (img, radius); } }),
-        std::make_pair ("naive class", BlurFunction { [&] (juce::Image& img, int radius) { melatonin::NaiveStackBlur stackBlur (img, radius); } }),
-        std::make_pair ("templated function", BlurFunction { [&] (juce::Image& img, int radius) { melatonin::stackBlur::singleChannelTemplated (img, radius); } }),
+        //std::make_pair ("naive class", BlurFunction { [&] (juce::Image& img, int radius) { melatonin::NaiveStackBlur stackBlur (img, radius); } }),
+        //std::make_pair ("templated function", BlurFunction { [&] (juce::Image& img, int radius) { melatonin::stackBlur::singleChannelTemplated (img, radius); } }),
         //        std::make_pair ("templated function float", BlurFunction { [&] (juce::Image& img, int radius) { melatonin::stackBlur::templatedFloatSingleChannel (img, radius); } }),
         std::make_pair ("Melatonin", BlurFunction { [&] (juce::Image& img, int radius) { melatonin::blur::singleChannel (img, radius); } }));
 }
@@ -72,17 +72,20 @@ TEST_CASE ("Melatonin Blur")
     SECTION ("single channel horizontal pass radius 1")
     {
         juce::Image image (juce::Image::PixelFormat::SingleChannel, 10, 1, true);
-        juce::Image::BitmapData data (image, juce::Image::BitmapData::readWrite);
 
         SECTION ("all bright")
         {
             // These calls actually have to be in the section for GENERATE to work
             const auto& [name, blur] = singleColorBlurImplementation();
 
-            // fill image with 1.0
-            for (auto x = 0; x < image.getWidth(); ++x)
             {
-                data.setPixelColour (x, 0, juce::Colours::black);
+                juce::Image::BitmapData data (image, juce::Image::BitmapData::readWrite);
+
+                // fill image with 1.0
+                for (auto x = 0; x < image.getWidth(); ++x)
+                {
+                    data.setPixelColour (x, 0, juce::Colours::black);
+                }
             }
             std::vector<float> expected = { 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f };
 
@@ -97,8 +100,12 @@ TEST_CASE ("Melatonin Blur")
         {
             const auto& [name, blur] = singleColorBlurImplementation();
 
-            data.setPixelColour (4, 0, juce::Colours::black);
-            data.setPixelColour (5, 0, juce::Colours::black);
+            {
+                juce::Image::BitmapData data (image, juce::Image::BitmapData::readWrite);
+
+                data.setPixelColour (4, 0, juce::Colours::black);
+                data.setPixelColour (5, 0, juce::Colours::black);
+            }
 
             std::vector<float> expected = { 0.0f, 0.0f, 0.0f, 0.24706f, 0.74902f, 0.74902f, 0.24706f, 0.0f, 0.0f, 0.0f };
 
@@ -113,8 +120,12 @@ TEST_CASE ("Melatonin Blur")
         {
             const auto& [name, blur] = singleColorBlurImplementation();
 
-            data.setPixelColour (0, 0, juce::Colours::black);
-            data.setPixelColour (9, 0, juce::Colours::black);
+            {
+                juce::Image::BitmapData data (image, juce::Image::BitmapData::readWrite);
+
+                data.setPixelColour (0, 0, juce::Colours::black);
+                data.setPixelColour (9, 0, juce::Colours::black);
+            }
 
             std::vector<float> expected = { 0.74902f, 0.24706f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.24706f, 0.74902f };
 
@@ -129,16 +140,19 @@ TEST_CASE ("Melatonin Blur")
     SECTION ("single channel horizontal pass radius 2")
     {
         juce::Image image (juce::Image::PixelFormat::SingleChannel, 10, 1, true);
-        juce::Image::BitmapData data (image, juce::Image::BitmapData::readWrite);
 
         SECTION ("all bright")
         {
             const auto& [name, blur] = singleColorBlurImplementation();
 
-            // fill image with 1.0
-            for (auto x = 0; x < image.getWidth(); ++x)
             {
-                data.setPixelColour (x, 0, juce::Colours::black);
+                juce::Image::BitmapData data (image, juce::Image::BitmapData::readWrite);
+
+                // fill image with 1.0
+                for (auto x = 0; x < image.getWidth(); ++x)
+                {
+                    data.setPixelColour (x, 0, juce::Colours::black);
+                }
             }
 
             std::vector<float> expected = { 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f };
@@ -151,10 +165,15 @@ TEST_CASE ("Melatonin Blur")
 
         SECTION ("center 2 bright has symmetrical result")
         {
+
             const auto& [name, blur] = singleColorBlurImplementation();
 
-            data.setPixelColour (4, 0, juce::Colours::black);
-            data.setPixelColour (5, 0, juce::Colours::black);
+            {
+                juce::Image::BitmapData data (image, juce::Image::BitmapData::readWrite);
+
+                data.setPixelColour (4, 0, juce::Colours::black);
+                data.setPixelColour (5, 0, juce::Colours::black);
+            }
 
             std::vector<float> expected = { 0.0f, 0.0f, 0.1098f, 0.33333f, 0.55294f, 0.55294f, 0.33333f, 0.1098f, 0.0f, 0.0f };
 
@@ -169,8 +188,12 @@ TEST_CASE ("Melatonin Blur")
         {
             const auto& [name, blur] = singleColorBlurImplementation();
 
-            data.setPixelColour (0, 0, juce::Colours::black);
-            data.setPixelColour (9, 0, juce::Colours::black);
+            {
+                juce::Image::BitmapData data (image, juce::Image::BitmapData::readWrite);
+
+                data.setPixelColour (0, 0, juce::Colours::black);
+                data.setPixelColour (9, 0, juce::Colours::black);
+            }
 
             std::vector<float> expected = { 0.66667f, 0.33333f, 0.1098f, 0.0f, 0.0f, 0.0f, 0.0f, 0.1098f, 0.33333f, 0.66667f };
 
@@ -184,9 +207,13 @@ TEST_CASE ("Melatonin Blur")
         SECTION ("every other bright")
         {
             const auto& [name, blur] = singleColorBlurImplementation();
-            for (auto x = 0; x < image.getWidth(); x += 2)
             {
-                data.setPixelColour (x, 0, juce::Colours::black);
+                juce::Image::BitmapData data (image, juce::Image::BitmapData::readWrite);
+
+                for (auto x = 0; x < image.getWidth(); x += 2)
+                {
+                    data.setPixelColour (x, 0, juce::Colours::black);
+                }
             }
 
             std::vector<float> expected = { 0.77647f, 0.55294f, 0.55294f, 0.44314f, 0.55294f, 0.44314f, 0.55294f, 0.44314f, 0.44314f, 0.21961f };
@@ -202,9 +229,13 @@ TEST_CASE ("Melatonin Blur")
         {
             const auto& [name, blur] = singleColorBlurImplementation();
 
-            for (auto x = 0; x < image.getWidth(); x += 3)
             {
-                data.setPixelColour (x, 0, juce::Colours::black);
+                juce::Image::BitmapData data (image, juce::Image::BitmapData::readWrite);
+
+                for (auto x = 0; x < image.getWidth(); x += 3)
+                {
+                    data.setPixelColour (x, 0, juce::Colours::black);
+                }
             }
 
             std::vector<float> expected = { 0.66667f, 0.44314f, 0.33333f, 0.33333f, 0.33333f, 0.33333f, 0.33333f, 0.33333f, 0.44314f, 0.66667f };
@@ -220,16 +251,19 @@ TEST_CASE ("Melatonin Blur")
     SECTION ("single channel vertical pass")
     {
         juce::Image image (juce::Image::PixelFormat::SingleChannel, 1, 10, true);
-        juce::Image::BitmapData data (image, juce::Image::BitmapData::readWrite);
 
         SECTION ("all bright radius 2")
         {
             const auto& [name, blur] = singleColorBlurImplementation();
 
-            // fill image with 1.0
-            for (auto y = 0; y < image.getHeight(); ++y)
             {
-                data.setPixelColour (0, y, juce::Colours::black);
+                juce::Image::BitmapData data (image, juce::Image::BitmapData::readWrite);
+
+                // fill image with 1.0
+                for (auto y = 0; y < image.getHeight(); ++y)
+                {
+                    data.setPixelColour (0, y, juce::Colours::black);
+                }
             }
 
             std::vector<float> expected = { 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f };
@@ -244,8 +278,13 @@ TEST_CASE ("Melatonin Blur")
         SECTION ("center 2 bright has symmetrical result radius 1")
         {
             const auto& [name, blur] = singleColorBlurImplementation();
-            data.setPixelColour (0, 4, juce::Colours::black);
-            data.setPixelColour (0, 5, juce::Colours::black);
+
+            {
+                juce::Image::BitmapData data (image, juce::Image::BitmapData::readWrite);
+
+                data.setPixelColour (0, 4, juce::Colours::black);
+                data.setPixelColour (0, 5, juce::Colours::black);
+            }
 
             // the vertical pass compounds on the horizontal, so this looks different from the horizontal pass result of
             //  { 0.0f, 0.0f, 0.1098f, 0.33333f, 0.55294f, 0.55294f, 0.33333f, 0.1098f, 0.0f, 0.0f }
@@ -262,7 +301,6 @@ TEST_CASE ("Melatonin Blur")
     SECTION ("Happy in 2D")
     {
         juce::Image image (juce::Image::PixelFormat::SingleChannel, 10, 10, true);
-        juce::Image::BitmapData data (image, juce::Image::BitmapData::readWrite);
 
         std::vector<float> edge = { 0.74902f, 0.74902f, 0.74902f, 0.74902f, 0.74902f, 0.74902f, 0.74902f, 0.74902f, 0.74902f, 0.74902f };
         std::vector<float> nextToEdge = { 0.24706f, 0.24706f, 0.24706f, 0.24706f, 0.24706f, 0.24706f, 0.24706f, 0.24706f, 0.24706f, 0.24706f };
@@ -272,10 +310,14 @@ TEST_CASE ("Melatonin Blur")
         {
             const auto& [name, blur] = singleColorBlurImplementation();
 
-            // fill image with 1.0
-            for (auto x = 0; x < image.getHeight(); ++x)
             {
-                data.setPixelColour (x, 0, juce::Colours::black);
+                juce::Image::BitmapData data (image, juce::Image::BitmapData::readWrite);
+
+                // fill image with 1.0
+                for (auto x = 0; x < image.getHeight(); ++x)
+                {
+                    data.setPixelColour (x, 0, juce::Colours::black);
+                }
             }
 
             DYNAMIC_SECTION (name)
@@ -294,10 +336,14 @@ TEST_CASE ("Melatonin Blur")
         {
             const auto& [name, blur] = singleColorBlurImplementation();
 
-            // left edge at 1.0
-            for (auto y = 0; y < image.getHeight(); ++y)
             {
-                data.setPixelColour (0, y, juce::Colours::black);
+                juce::Image::BitmapData data (image, juce::Image::BitmapData::readWrite);
+
+                // left edge at 1.0
+                for (auto y = 0; y < image.getHeight(); ++y)
+                {
+                    data.setPixelColour (0, y, juce::Colours::black);
+                }
             }
 
             DYNAMIC_SECTION (name)
@@ -316,10 +362,14 @@ TEST_CASE ("Melatonin Blur")
         {
             const auto& [name, blur] = singleColorBlurImplementation();
 
-            // right edge at 1.0
-            for (auto y = 0; y < image.getHeight(); ++y)
             {
-                data.setPixelColour (image.getWidth() - 1, y, juce::Colours::black);
+                juce::Image::BitmapData data (image, juce::Image::BitmapData::readWrite);
+
+                // right edge at 1.0
+                for (auto y = 0; y < image.getHeight(); ++y)
+                {
+                    data.setPixelColour (image.getWidth() - 1, y, juce::Colours::black);
+                }
             }
 
             DYNAMIC_SECTION (name)
@@ -338,10 +388,14 @@ TEST_CASE ("Melatonin Blur")
         {
             const auto& [name, blur] = singleColorBlurImplementation();
 
-            // bottom edge at 1.0
-            for (auto x = 0; x < image.getWidth(); ++x)
             {
-                data.setPixelColour (x, image.getHeight() - 1, juce::Colours::black);
+                juce::Image::BitmapData data (image, juce::Image::BitmapData::readWrite);
+
+                // bottom edge at 1.0
+                for (auto x = 0; x < image.getWidth(); ++x)
+                {
+                    data.setPixelColour (x, image.getHeight() - 1, juce::Colours::black);
+                }
             }
 
             DYNAMIC_SECTION (name)
@@ -360,17 +414,21 @@ TEST_CASE ("Melatonin Blur")
         {
             const auto& [name, blur] = singleColorBlurImplementation();
 
-            // outline with 1.0
-            for (auto y = 0; y < image.getHeight(); ++y)
             {
-                data.setPixelColour (0, y, juce::Colours::black);
-                data.setPixelColour (image.getWidth() - 1, y, juce::Colours::black);
-            }
+                juce::Image::BitmapData data (image, juce::Image::BitmapData::readWrite);
 
-            for (auto x = 0; x < image.getWidth(); ++x)
-            {
-                data.setPixelColour (x, 0, juce::Colours::black);
-                data.setPixelColour (x, image.getHeight() - 1, juce::Colours::black);
+                // outline with 1.0
+                for (auto y = 0; y < image.getHeight(); ++y)
+                {
+                    data.setPixelColour (0, y, juce::Colours::black);
+                    data.setPixelColour (image.getWidth() - 1, y, juce::Colours::black);
+                }
+
+                for (auto x = 0; x < image.getWidth(); ++x)
+                {
+                    data.setPixelColour (x, 0, juce::Colours::black);
+                    data.setPixelColour (x, image.getHeight() - 1, juce::Colours::black);
+                }
             }
 
             std::vector<float> corners = { 0.93725f, 0.81176f, 0.74902f, 0.74902f, 0.74902f, 0.74902f, 0.74902f, 0.74902f, 0.81176f, 0.93725f };
@@ -419,16 +477,19 @@ TEST_CASE ("Melatonin Blur")
         SECTION ("Horizontal Pass (10x1 image size)")
         {
             juce::Image image (juce::Image::PixelFormat::ARGB, 10, 1, true);
-            juce::Image::BitmapData data (image, juce::Image::BitmapData::readWrite);
 
             SECTION ("red 1.0, green 1.0, blue 1.0")
             {
                 const auto& [name, blur] = rgbaBlurImplementation();
 
-                // fill image with 1.0
-                for (auto x = 0; x < image.getWidth(); ++x)
                 {
-                    data.setPixelColour (x, 0, juce::Colour::fromFloatRGBA (1.0f, 1.0f, 1.0f, 1.0f));
+                    juce::Image::BitmapData data (image, juce::Image::BitmapData::readWrite);
+
+                    // fill image with 1.0
+                    for (auto x = 0; x < image.getWidth(); ++x)
+                    {
+                        data.setPixelColour (x, 0, juce::Colour::fromFloatRGBA (1.0f, 1.0f, 1.0f, 1.0f));
+                    }
                 }
 
                 //  underlying colors are 8-bit (0-255) so translation back to float is messy
@@ -469,13 +530,17 @@ TEST_CASE ("Melatonin Blur")
 
                         std::vector<float> expected (image.getWidth());
 
-                        // add copies of this pixel to the image and expected
-                        for (auto x = 0; x < image.getWidth(); ++x)
                         {
-                            // yeah, this is sort of a mindfuck, going from BGRA -> RGBA
-                            auto pixelColor = juce::Colour::fromFloatRGBA (pixel[2], pixel[1], pixel[0], pixel[3]);
-                            data.setPixelColour (x, 0, pixelColor);
-                            expected[x] = pixel[i];
+                            juce::Image::BitmapData data (image, juce::Image::BitmapData::readWrite);
+
+                            // add copies of this pixel to the image and expected
+                            for (auto x = 0; x < image.getWidth(); ++x)
+                            {
+                                // yeah, this is sort of a mindfuck, going from BGRA -> RGBA
+                                auto pixelColor = juce::Colour::fromFloatRGBA (pixel[2], pixel[1], pixel[0], pixel[3]);
+                                data.setPixelColour (x, 0, pixelColor);
+                                expected[x] = pixel[i];
+                            }
                         }
 
                         // make sure we set the pixels correctly to begin with
@@ -493,8 +558,12 @@ TEST_CASE ("Melatonin Blur")
             {
                 const auto& [name, blur] = rgbaBlurImplementation();
 
-                data.setPixelColour (4, 0, juce::Colours::white);
-                data.setPixelColour (5, 0, juce::Colours::white);
+                {
+                    juce::Image::BitmapData data (image, juce::Image::BitmapData::readWrite);
+
+                    data.setPixelColour (4, 0, juce::Colours::white);
+                    data.setPixelColour (5, 0, juce::Colours::white);
+                }
 
                 // initial state
                 std::vector<float> initial = { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f };
@@ -520,15 +589,16 @@ TEST_CASE ("Melatonin Blur")
         SECTION ("Vertical Pass (1x10 image size)")
         {
             juce::Image image (juce::Image::PixelFormat::ARGB, 1, 10, true);
-            juce::Image::BitmapData data (image, juce::Image::BitmapData::readWrite);
 
             SECTION ("center 2 bright is symmetrical in each channel")
             {
                 const auto& [name, blur] = rgbaBlurImplementation();
 
-                data.setPixelColour (0, 4, juce::Colours::white);
-                data.setPixelColour (0, 5, juce::Colours::white);
-
+                {
+                    juce::Image::BitmapData data (image, juce::Image::BitmapData::readWrite);
+                    data.setPixelColour (0, 4, juce::Colours::white);
+                    data.setPixelColour (0, 5, juce::Colours::white);
+                }
                 // initial state
                 std::vector<float> initial = { 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f };
 

--- a/tests/composite_argb.cpp
+++ b/tests/composite_argb.cpp
@@ -15,8 +15,6 @@ TEST_CASE ("Melatonin Blur Composite ARGB")
     {
         // boot up the bare minimum of a CachedShadow
         juce::Image context (juce::Image::PixelFormat::ARGB, 20, 20, true);
-        juce::Graphics g (context);
-        g.fillAll (juce::Colours::white);
 
         SECTION ("match a single channel blur")
         {
@@ -26,7 +24,12 @@ TEST_CASE ("Melatonin Blur Composite ARGB")
             // make a 4x4 at 2,2
             p.addRectangle (juce::Rectangle<float> (2, 2, 4, 4));
             auto shadow = melatonin::DropShadow ({ s1 });
-            shadow.render (g, p);
+
+            {
+                juce::Graphics g (context);
+                g.fillAll (juce::Colours::white);
+                shadow.render (g, p);
+            }
 
             // check bounds of non-white rectangle
             CHECK (filledBounds (context) == juce::Rectangle<int> (0, 0, 8, 8));
@@ -40,7 +43,12 @@ TEST_CASE ("Melatonin Blur Composite ARGB")
             // make a 4x4 at 2,2
             p.addRectangle (juce::Rectangle<float> (2, 2, 4, 4));
             auto shadow = melatonin::DropShadow ({ s1 });
-            shadow.render (g, p);
+
+            {
+                juce::Graphics g (context);
+                g.fillAll (juce::Colours::white);
+                shadow.render (g, p);
+            }
 
             save_test_image (context, "offset");
 
@@ -58,8 +66,13 @@ TEST_CASE ("Melatonin Blur Composite ARGB")
             juce::Path p;
             // make a 4x4 at 2,2
             p.addRectangle (juce::Rectangle<float> (3, 3, 4, 4));
-            auto shadow = melatonin::DropShadow ({ s1, s2 });
-            shadow.render (g, p);
+
+            {
+                juce::Graphics g (context);
+                g.fillAll (juce::Colours::white);
+                auto shadow = melatonin::DropShadow ({ s1, s2 });
+                shadow.render (g, p);
+            }
 
             // check bounds of non-white rectangle
             CHECK (filledBounds (context).toString() == juce::Rectangle<int> (0, 0, 10, 10).toString());
@@ -75,8 +88,13 @@ TEST_CASE ("Melatonin Blur Composite ARGB")
             juce::Path p;
             // make a 4x4 at 2,2
             p.addRectangle (juce::Rectangle<float> (2, 2, 4, 4));
-            auto shadow = melatonin::DropShadow ({ s1, s2 });
-            shadow.render (g, p);
+            {
+                juce::Graphics g (context);
+                g.fillAll (juce::Colours::white);
+
+                auto shadow = melatonin::DropShadow ({ s1, s2 });
+                shadow.render (g, p);
+            }
 
             // check bounds of non-white rectangle
             // it's just 2px wider
@@ -91,9 +109,15 @@ TEST_CASE ("Melatonin Blur Composite ARGB")
             // make a 4x4 at 2,2
             p.addRectangle (juce::Rectangle<float> (2, 2, 4, 4));
             auto shadow = melatonin::DropShadow ({ s1 });
-            shadow.render (g, p);
 
-            save_test_image(context, "zero_radius");
+            {
+                juce::Graphics g (context);
+                g.fillAll (juce::Colours::white);
+
+                shadow.render (g, p);
+            }
+
+            save_test_image (context, "zero_radius");
 
             // check bounds of non-white rectangle
             CHECK (filledBounds (context).toString() == juce::Rectangle<int> (2, 2, 4, 4).toString());
@@ -104,7 +128,7 @@ TEST_CASE ("Melatonin Blur Composite ARGB")
     {
         juce::Image context (juce::Image::PixelFormat::ARGB, 150, 150, true);
         juce::Graphics g (context);
-        g.addTransform(juce::AffineTransform::scale (2));
+        g.addTransform (juce::AffineTransform::scale (2));
         g.fillAll (juce::Colours::white);
 
         auto dummyShadow = melatonin::ShadowParameters ({ juce::Colours::black, 2, { 0, 0 }, 0 });
@@ -118,9 +142,9 @@ TEST_CASE ("Melatonin Blur Composite ARGB")
         auto shadow = melatonin::InnerShadow (dummyShadow);
         shadow.render (g, p);
         auto originalPath = shadow.lastOriginAgnosticPath;
-        shadow.render(g, p);
+        shadow.render (g, p);
         auto translatedPath = shadow.lastOriginAgnosticPath;
 
-        CHECK(originalPath == translatedPath);
+        CHECK (originalPath == translatedPath);
     }
 }

--- a/tests/drop_shadow.cpp
+++ b/tests/drop_shadow.cpp
@@ -491,5 +491,5 @@ TEST_CASE ("Melatonin Blur JUCE premultiplied check")
         CHECK (actualPixel.g == 0u);
         CHECK (actualPixel.b == 0u);
     }
-};
+}
 #endif

--- a/tests/drop_shadow.cpp
+++ b/tests/drop_shadow.cpp
@@ -1,5 +1,5 @@
-#include "../melatonin/shadows.h"
 #include "../melatonin/internal/implementations.h"
+#include "../melatonin/shadows.h"
 #include "helpers/pixel_helpers.h"
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -31,15 +31,16 @@ TEST_CASE ("Melatonin Blur Drop Shadow")
     juce::ScopedJuceInitialiser_GUI juce;
 
     juce::Image result (juce::Image::ARGB, 9, 9, true);
-    juce::Graphics g (result);
 
     SECTION ("no shadow")
     {
-        g.fillAll (juce::Colours::white);
-
-        g.setColour (juce::Colours::black);
-        g.fillPath (p);
-
+        {
+            juce::Graphics g (result);
+            g.fillAll (juce::Colours::white);
+            g.setColour (juce::Colours::black);
+            g.fillPath (p);
+        }
+        save_test_image (result, "no shadow");
         // nothing should be outside the top left corner
         REQUIRE (result.getPixelAt (2, 2).toDisplayString (true) == "FFFFFFFF"); // ARGB
 
@@ -49,32 +50,41 @@ TEST_CASE ("Melatonin Blur Drop Shadow")
 
     SECTION ("default constructor")
     {
-        g.fillAll (juce::Colours::white);
         melatonin::DropShadow shadow;
 
         SECTION ("doesn't setup a shadow, renders nothing")
         {
-            shadow.render (g, p);
+            {
+                juce::Graphics g (result);
+                g.fillAll (juce::Colours::white);
+                shadow.render (g, p);
+            }
             CHECK (filledBounds (result).toString() == juce::Rectangle<int> (0, 0, 0, 0).toString());
         }
 
         // the point of this is to allow everything to be efficient
         SECTION ("modify the shadow, it renders a default black shadow")
         {
-            save_test_image (result, "default constructor");
-            shadow.setRadius (5);
-            shadow.render (g, p);
+            {
+                juce::Graphics g (result);
+                g.fillAll (juce::Colours::white);
+                shadow.setRadius (5);
+                shadow.render (g, p);
+            }
             CHECK (filledBounds (result) == juce::Rectangle<int> (0, 0, 9, 9));
         }
     }
 
     SECTION ("single shadow")
     {
-        g.fillAll (juce::Colours::white);
-        melatonin::DropShadow shadow = { { juce::Colours::black, 2 } };
-        shadow.render (g, p);
-        g.setColour (juce::Colours::black);
-        g.fillPath (p);
+        {
+            juce::Graphics g (result);
+            g.fillAll (juce::Colours::white);
+            melatonin::DropShadow shadow = { { juce::Colours::black, 2 } };
+            shadow.render (g, p);
+            g.setColour (juce::Colours::black);
+            g.fillPath (p);
+        }
         save_test_image (result, "single_shadow");
 
         // TODO: I'd like to reduce the margin on these tests
@@ -128,16 +138,17 @@ TEST_CASE ("Melatonin Blur Drop Shadow")
 
     SECTION ("offset")
     {
-        g.fillAll (juce::Colours::white);
-
         SECTION ("positive 1px for x/y")
         {
-            // offset by 1px to the right/bottom
-            melatonin::DropShadow shadow = { { juce::Colours::black, 2, { 1, 1 } } };
-            shadow.render (g, p);
-            g.setColour (juce::Colours::black);
-            g.fillPath (p);
-
+            {
+                juce::Graphics g (result);
+                g.fillAll (juce::Colours::white);
+                // offset by 1px to the right/bottom
+                melatonin::DropShadow shadow = { { juce::Colours::black, 2, { 1, 1 } } };
+                shadow.render (g, p);
+                g.setColour (juce::Colours::black);
+                g.fillPath (p);
+            }
             save_test_image (result, "positive 1px offset");
 
             SECTION ("left and top edges have an extra white pixel")
@@ -164,19 +175,27 @@ TEST_CASE ("Melatonin Blur Drop Shadow")
         {
             SECTION ("negative Y offset means top pixel is no longer white")
             {
-                melatonin::DropShadow shadow = { { juce::Colours::black, 2, { 0, -1 } } };
-                shadow.render (g, p);
-                g.setColour (juce::Colours::black);
-                g.fillPath (p);
+                {
+                    juce::Graphics g (result);
+                    g.fillAll (juce::Colours::white);
+                    melatonin::DropShadow shadow = { { juce::Colours::black, 2, { 0, -1 } } };
+                    shadow.render (g, p);
+                    g.setColour (juce::Colours::black);
+                    g.fillPath (p);
+                }
                 CHECK (result.getPixelAt (4, 0).getBrightness() == Catch::Approx (0.91372549).margin (0.01)); // 1st px of blur
             }
 
             SECTION ("negative X offset means left pixel is no longer white")
             {
-                melatonin::DropShadow shadow = { { juce::Colours::black, 2, { -1, 0 } } };
-                shadow.render (g, p);
-                g.setColour (juce::Colours::black);
-                g.fillPath (p);
+                {
+                    juce::Graphics g (result);
+                    g.fillAll (juce::Colours::white);
+                    melatonin::DropShadow shadow = { { juce::Colours::black, 2, { -1, 0 } } };
+                    shadow.render (g, p);
+                    g.setColour (juce::Colours::black);
+                    g.fillPath (p);
+                }
                 CHECK (result.getPixelAt (0, 4).getBrightness() == Catch::Approx (0.91372549).margin (.01)); // 1st px of blur
             }
         }
@@ -184,14 +203,16 @@ TEST_CASE ("Melatonin Blur Drop Shadow")
 
     SECTION ("spread")
     {
-        g.fillAll (juce::Colours::white);
-
         SECTION ("positive")
         {
-            melatonin::DropShadow shadow = { { juce::Colours::black, 2, {}, 2 } };
-            shadow.render (g, p);
-            g.setColour (juce::Colours::black);
-            g.fillPath (p);
+            {
+                juce::Graphics g (result);
+                g.fillAll (juce::Colours::white);
+                melatonin::DropShadow shadow = { { juce::Colours::black, 2, {}, 2 } };
+                shadow.render (g, p);
+                g.setColour (juce::Colours::black);
+                g.fillPath (p);
+            }
 
             SECTION ("no more white pixels, since the blur has spread out")
             {
@@ -209,11 +230,15 @@ TEST_CASE ("Melatonin Blur Drop Shadow")
         {
             SECTION ("reduces the size of the blur by 1px")
             {
-                melatonin::DropShadow shadow = { { juce::Colours::black, 2, {}, -1 } };
-                shadow.render (g, p);
-                g.setColour (juce::Colours::black);
-                g.fillPath (p);
+                {
+                    juce::Graphics g (result);
+                    g.fillAll (juce::Colours::white);
 
+                    melatonin::DropShadow shadow = { { juce::Colours::black, 2, {}, -1 } };
+                    shadow.render (g, p);
+                    g.setColour (juce::Colours::black);
+                    g.fillPath (p);
+                }
                 // extra white pixel, as if path were smaller (because it is)
                 CHECK (result.getPixelAt (0, 4).toDisplayString (true) == "FFFFFFFF");
                 CHECK (result.getPixelAt (1, 4).toDisplayString (true) == "FFFFFFFF");
@@ -227,10 +252,14 @@ TEST_CASE ("Melatonin Blur Drop Shadow")
                 // spread can't be more than -1 in our example, since our path is 3x3
                 melatonin::DropShadow shadow = { { juce::Colours::black, 1, {}, -1 } };
 
-                shadow.render (g, p);
-                g.setColour (juce::Colours::black);
-                g.fillPath (p);
+                {
+                    juce::Graphics g (result);
+                    g.fillAll (juce::Colours::white);
 
+                    shadow.render (g, p);
+                    g.setColour (juce::Colours::black);
+                    g.fillPath (p);
+                }
                 CHECK (result.getPixelAt (2, 2).toDisplayString (true) == "FFFFFFFF");
                 CHECK (result.getPixelAt (2, 3).toDisplayString (true) == "FFFFFFFF");
             }
@@ -262,13 +291,15 @@ TEST_CASE ("Melatonin Blur Drop Shadow")
 
     SECTION ("multiple shadow colors")
     {
-        g.fillAll (juce::Colours::white);
-
         // dammit, in JUCE "lime" is actually pure green...
         melatonin::DropShadow shadow = { { juce::Colours::red, 2 }, { juce::Colours::lime, 2 } };
 
         SECTION ("to start, our context is white")
         {
+            {
+                juce::Graphics g (result);
+                g.fillAll (juce::Colours::white);
+            }
             auto color = result.getPixelAt (4, 4);
             CHECK (color.getFloatRed() == Catch::Approx (1.0f));
             CHECK (color.getFloatGreen() == Catch::Approx (1.0f));
@@ -278,9 +309,13 @@ TEST_CASE ("Melatonin Blur Drop Shadow")
         // TODO: figure out red/green discrepancy
         SECTION ("post shadow, red and green are present", "[.]")
         {
-            shadow.render (g, p);
+            {
+                juce::Graphics g (result);
+                g.fillAll (juce::Colours::white);
+                shadow.render (g, p);
+            }
             auto color = result.getPixelAt (4, 4);
-            CHECK (color.getFloatRed() == Catch::Approx (0.4f)); // TODO: no idea wtf
+            CHECK (color.getFloatRed() == Catch::Approx (0.4f).margin(0.005)); // TODO: no idea wtf
             CHECK (color.getFloatGreen() == Catch::Approx (0.76471f).margin (0.005));
             CHECK (color.getFloatBlue() == Catch::Approx (0.16078f).margin (0.005));
         }
@@ -288,12 +323,14 @@ TEST_CASE ("Melatonin Blur Drop Shadow")
 
     SECTION ("Alpha")
     {
-        g.fillAll (juce::Colours::white);
-
         SECTION ("alpha of 0 is invisible")
         {
-            melatonin::DropShadow shadow = { { juce::Colours::black.withAlpha (0.0f), 2 } };
-            shadow.render (g, p);
+            {
+                juce::Graphics g (result);
+                g.fillAll (juce::Colours::white);
+                melatonin::DropShadow shadow = { { juce::Colours::black.withAlpha (0.0f), 2 } };
+                shadow.render (g, p);
+            }
 
             // the entire image is still white
             CHECK (isImageFilled (result, juce::Colours::white) == true);
@@ -301,8 +338,12 @@ TEST_CASE ("Melatonin Blur Drop Shadow")
 
         SECTION ("alpha of 1 is opaque")
         {
-            melatonin::DropShadow shadow = { { juce::Colours::black.withAlpha (1.0f), 2 } };
-            shadow.render (g, p);
+            {
+                juce::Graphics g (result);
+                g.fillAll (juce::Colours::white);
+                melatonin::DropShadow shadow = { { juce::Colours::black.withAlpha (1.0f), 2 } };
+                shadow.render (g, p);
+            }
 
             // center pixel of blur is not black (0), but pretty dark still
             CHECK (result.getPixelAt (4, 4).getLightness() == Catch::Approx (0.39608f).margin (0.01));
@@ -310,8 +351,13 @@ TEST_CASE ("Melatonin Blur Drop Shadow")
 
         SECTION ("alpha of 0.5 is translucent")
         {
-            melatonin::DropShadow shadow = { { juce::Colours::black.withAlpha (0.5f), 2 } };
-            shadow.render (g, p);
+            {
+                juce::Graphics g (result);
+                g.fillAll (juce::Colours::white);
+
+                melatonin::DropShadow shadow = { { juce::Colours::black.withAlpha (0.5f), 2 } };
+                shadow.render (g, p);
+            }
 
             // center pixel of blur is much lighter (remember, we're on white!)
             CHECK (result.getPixelAt (4, 4).getLightness() == Catch::Approx (0.69804f).margin (0.01));

--- a/tests/helpers/pixel_helpers.h
+++ b/tests/helpers/pixel_helpers.h
@@ -13,7 +13,7 @@ struct ActualPixel
 
 // it's just tests, take off your safety helmet and get dangerous with me!
 // macOS and windows are Little Endian, so unfortunately ARGB is stored "backwards" as BGRA
-[[nodiscard]] inline ActualPixel getActualARGBPixel (uint8_t* jucePixel)
+[[nodiscard]] [[maybe_unused]] inline ActualPixel getActualARGBPixel (uint8_t* jucePixel)
 {
 #if JUCE_BIG_ENDIAN
     return { jucePixel[0], jucePixel[1], jucePixel[2], jucePixel[3] };
@@ -38,7 +38,7 @@ inline void setActualPixel (uint8_t* jucePixel, ActualPixel actualPixel)
 }
 
 // ugly, but makes testing more readable via float arrays
-static std::vector<float> pixelRow (const juce::Image& image, int row, int channel = -1)
+[[maybe_unused]] static std::vector<float> pixelRow (const juce::Image& image, int row, int channel = -1)
 {
     auto singleChannel = image.getFormat() == juce::Image::PixelFormat::SingleChannel;
     std::vector<float> result;
@@ -69,7 +69,7 @@ static std::vector<float> pixelRow (const juce::Image& image, int row, int chann
     }
     return result;
 }
-static std::vector<float> pixelCol (const juce::Image& image, int col, int channel = -1)
+[[maybe_unused]] static std::vector<float> pixelCol (const juce::Image& image, int col, int channel = -1)
 {
     std::vector<float> result;
     juce::Image::BitmapData data (image, juce::Image::BitmapData::readOnly);
@@ -97,12 +97,12 @@ static std::vector<float> pixelCol (const juce::Image& image, int col, int chann
     return result;
 }
 
-static juce::String getPixel (juce::Image& img, int x, int y)
+[[maybe_unused]] static juce::String getPixel (juce::Image& img, int x, int y)
 {
     return img.getPixelAt (x, y).toDisplayString (true);
 }
 
-static float getScaledBrightness (juce::Image& img, int x, int y, float scale)
+[[maybe_unused]] static float getScaledBrightness (juce::Image& img, int x, int y, float scale)
 {
     x = juce::roundToInt ((float) x * scale);
     y = juce::roundToInt ((float) y * scale);
@@ -110,7 +110,7 @@ static float getScaledBrightness (juce::Image& img, int x, int y, float scale)
 }
 
 // get pixels in a range, *includes* the start/end of range
-static juce::String getPixels (juce::Image& img, int x, juce::Range<int> yRange)
+[[maybe_unused]] static juce::String getPixels (juce::Image& img, int x, juce::Range<int> yRange)
 {
     juce::String result;
     for (auto y = yRange.getStart(); y <= yRange.getEnd(); ++y)
@@ -122,7 +122,7 @@ static juce::String getPixels (juce::Image& img, int x, juce::Range<int> yRange)
     return result;
 }
 
-static juce::String getPixels (juce::Image& img, juce::Range<int> xRange, int y)
+[[maybe_unused]] static juce::String getPixels (juce::Image& img, juce::Range<int> xRange, int y)
 {
     juce::String result;
     for (auto x = xRange.getStart(); x <= xRange.getEnd(); ++x)
@@ -134,7 +134,7 @@ static juce::String getPixels (juce::Image& img, juce::Range<int> xRange, int y)
     return result;
 }
 
-static juce::String getPixels (juce::Image& img, juce::Range<int> xRange, juce::Range<int> yRange)
+[[maybe_unused]] static juce::String getPixels (juce::Image& img, juce::Range<int> xRange, juce::Range<int> yRange)
 {
     juce::String result;
     for (auto y = yRange.getStart(); y <= yRange.getEnd(); ++y)
@@ -149,7 +149,7 @@ static juce::String getPixels (juce::Image& img, juce::Range<int> xRange, juce::
     return result;
 }
 
-static std::vector<float> getPixelsBrightness (juce::Image& img, int x, juce::Range<int> yRange)
+[[maybe_unused]] static std::vector<float> getPixelsBrightness (juce::Image& img, int x, juce::Range<int> yRange)
 {
     std::vector<float> result;
     for (auto y = yRange.getStart(); y <= yRange.getEnd(); ++y)
@@ -159,7 +159,7 @@ static std::vector<float> getPixelsBrightness (juce::Image& img, int x, juce::Ra
     return result;
 }
 
-static std::vector<float> getPixelsBrightness (juce::Image& img, juce::Range<int> xRange, int y)
+[[maybe_unused]] static std::vector<float> getPixelsBrightness (juce::Image& img, juce::Range<int> xRange, int y)
 {
     std::vector<float> result;
     for (auto x = xRange.getStart(); x <= xRange.getEnd(); ++x)
@@ -169,7 +169,7 @@ static std::vector<float> getPixelsBrightness (juce::Image& img, juce::Range<int
     return result;
 }
 
-static bool isImageFilled (const juce::Image& img, const juce::Colour& color)
+[[maybe_unused]] static bool isImageFilled (const juce::Image& img, const juce::Colour& color)
 {
     const juce::Image::BitmapData data (img, juce::Image::BitmapData::readOnly);
     for (auto y = 0; y < img.getHeight(); ++y)
@@ -180,10 +180,10 @@ static bool isImageFilled (const juce::Image& img, const juce::Colour& color)
 
             // TODO: again, windows compositing seems to need some leeway
             // Here, the alpha channel on the far right is 253 instead of 255
-            if (pixelColor.getFloatRed() !=  color.getFloatRed()
-                || pixelColor.getFloatGreen() != color.getFloatGreen()
-                || pixelColor.getFloatBlue() != color.getFloatBlue()
-                || std::abs(pixelColor.getFloatAlpha() - color.getFloatAlpha()) > 0.01f)
+            if (!juce::approximatelyEqual (pixelColor.getFloatRed(), color.getFloatRed())
+                || !juce::approximatelyEqual (pixelColor.getFloatGreen(), color.getFloatGreen())
+                || !juce::approximatelyEqual (pixelColor.getFloatBlue(), color.getFloatBlue())
+                || std::abs (pixelColor.getFloatAlpha() - color.getFloatAlpha()) > 0.01f)
                 return false;
         }
     }
@@ -192,7 +192,7 @@ static bool isImageFilled (const juce::Image& img, const juce::Colour& color)
 
 // tests all are on WHITE
 // so filled bounds have any other color than pure white
-static juce::Rectangle<int> filledBounds (juce::Image& img)
+[[maybe_unused]] static juce::Rectangle<int> filledBounds (juce::Image& img)
 {
     juce::Rectangle<int> result;
     juce::Image::BitmapData data (img, juce::Image::BitmapData::readOnly);
@@ -209,7 +209,7 @@ static juce::Rectangle<int> filledBounds (juce::Image& img)
     return result;
 }
 
-static bool imagesAreIdentical (juce::Image& img1, juce::Image& img2)
+[[maybe_unused]] static bool imagesAreIdentical (juce::Image& img1, juce::Image& img2)
 {
     juce::Image::BitmapData data1 (img1, juce::Image::BitmapData::readOnly);
     juce::Image::BitmapData data2 (img2, juce::Image::BitmapData::readOnly);
@@ -224,7 +224,7 @@ static bool imagesAreIdentical (juce::Image& img1, juce::Image& img2)
     return true;
 }
 
-static void print_test_image (juce::Image& image)
+[[maybe_unused]] static void print_test_image (juce::Image& image)
 {
     // this is meant for testing trivial examples
     jassert (image.getWidth() < 20 && image.getHeight() < 20);
@@ -245,7 +245,7 @@ static void print_test_image (juce::Image& image)
     std::cout << std::endl;
 }
 
-static void save_test_image (juce::Image& image, juce::String name = "test")
+[[maybe_unused]] static void save_test_image (juce::Image& image, juce::String name = "test")
 {
     juce::Image imageToSave = image;
     if (imageToSave.isSingleChannel())

--- a/tests/inner_shadow.cpp
+++ b/tests/inner_shadow.cpp
@@ -29,18 +29,19 @@ TEST_CASE ("Melatonin Blur Inner Shadow")
     p.addRectangle (bounds.translated (2, 2));
 
     // needed for JUCE not to pee its pants (aka leak) when working with graphics
-    juce::ScopedJuceInitialiser_GUI juce;
+    juce::ScopedJuceInitialiser_GUI gui;
 
     juce::Image result (juce::Image::ARGB, 9, 9, true);
-    juce::Graphics g (result);
 
     SECTION ("no shadow (sanity check)")
     {
-        g.fillAll (juce::Colours::white);
+        {
+            juce::Graphics g (result);
+            g.fillAll (juce::Colours::white);
 
-        g.setColour (juce::Colours::black);
-        g.fillPath (p);
-
+            g.setColour (juce::Colours::black);
+            g.fillPath (p);
+        }
         // nothing should be outside the top left corner
         REQUIRE (getPixel (result, 1, 1) == "FFFFFFFF"); // ARGB
 
@@ -50,24 +51,37 @@ TEST_CASE ("Melatonin Blur Inner Shadow")
 
     SECTION ("default constructor")
     {
-        g.fillAll (juce::Colours::white);
         melatonin::InnerShadow shadow;
-        shadow.render (g, p);
+        {
+            juce::Graphics g (result);
+
+            g.fillAll (juce::Colours::white);
+            shadow.render (g, p);
+        }
         CHECK (isImageFilled (result, juce::Colours::white) == true);
-        shadow.setRadius (5);
-        shadow.render (g, p);
+        {
+            juce::Graphics g (result);
+            shadow.setRadius (5);
+            shadow.render (g, p);
+        }
         CHECK (isImageFilled (result, juce::Colours::white) == false);
     }
 
     SECTION ("InnerShadow 2px")
     {
-        g.fillAll (juce::Colours::white);
         melatonin::InnerShadow shadow = { { juce::Colours::white, 2 } };
-        g.setColour (juce::Colours::black);
-        g.fillPath (p);
 
-        // inner shadow render must come AFTER the path render
-        shadow.render (g, p);
+        {
+            juce::Graphics g (result);
+            g.fillAll (juce::Colours::white);
+
+            g.fillAll (juce::Colours::white);
+            g.setColour (juce::Colours::black);
+            g.fillPath (p);
+
+            // inner shadow render must come AFTER the path render
+            shadow.render (g, p);
+        }
 
         save_test_image (result, "inner_shadow_2px");
 
@@ -121,15 +135,18 @@ TEST_CASE ("Melatonin Blur Inner Shadow")
                 auto centerWithoutSpread = result.getPixelAt (4, 4).getBrightness();
                 auto cornerWithoutSpread = result.getPixelAt (2, 2).getBrightness();
 
-                // redo the blur with spread
-                g.fillAll (juce::Colours::white);
-                melatonin::InnerShadow shadowWithPositiveSpread = { { juce::Colours::white, 2, {}, 1 } };
-                g.setColour (juce::Colours::black);
-                g.fillPath (p);
+                {
+                    juce::Graphics g (result);
+                    g.fillAll (juce::Colours::white);
 
-                // inner shadow render must come AFTER the path render
-                shadowWithPositiveSpread.render (g, p);
+                    // redo the blur with spread
+                    melatonin::InnerShadow shadowWithPositiveSpread = { { juce::Colours::white, 2, {}, 1 } };
+                    g.setColour (juce::Colours::black);
+                    g.fillPath (p);
 
+                    // inner shadow render must come AFTER the path render
+                    shadowWithPositiveSpread.render (g, p);
+                }
                 save_test_image (result, "inner_shadow_2px_positive_spread");
 
                 SECTION ("increases brightness at center")
@@ -151,13 +168,17 @@ TEST_CASE ("Melatonin Blur Inner Shadow")
             SECTION ("When there's more spread than radius")
             {
                 // redo the blur with spread
-                g.fillAll (juce::Colours::white);
-                melatonin::InnerShadow shadowWithPositiveSpread = { { juce::Colours::white, 1, {}, 2 } };
-                g.setColour (juce::Colours::black);
-                g.fillPath (p);
+                {
+                    juce::Graphics g (result);
+                    g.fillAll (juce::Colours::white);
 
-                shadowWithPositiveSpread.render (g, p);
+                    g.fillAll (juce::Colours::white);
+                    melatonin::InnerShadow shadowWithPositiveSpread = { { juce::Colours::white, 1, {}, 2 } };
+                    g.setColour (juce::Colours::black);
+                    g.fillPath (p);
 
+                    shadowWithPositiveSpread.render (g, p);
+                }
                 save_test_image (result, "more spread than radius");
 
                 SECTION ("edges of path are pure white")
@@ -178,13 +199,17 @@ TEST_CASE ("Melatonin Blur Inner Shadow")
             {
                 SECTION ("positive 2")
                 {
-                    g.fillAll (juce::Colours::white);
-                    shadow = { { juce::Colours::white, 2, { 2, 0 } } };
-                    g.setColour (juce::Colours::black);
-                    g.fillPath (p);
+                    {
+                        juce::Graphics g (result);
+                        g.fillAll (juce::Colours::white);
+                        g.fillAll (juce::Colours::white);
+                        shadow = { { juce::Colours::white, 2, { 2, 0 } } };
+                        g.setColour (juce::Colours::black);
+                        g.fillPath (p);
 
-                    // inner shadow render must come AFTER the path render
-                    shadow.render (g, p);
+                        // inner shadow render must come AFTER the path render
+                        shadow.render (g, p);
+                    }
 
                     save_test_image (result, "inner_shadow_2px_positive_offset_x");
 
@@ -206,14 +231,18 @@ TEST_CASE ("Melatonin Blur Inner Shadow")
 
                 SECTION ("offset greater than radius matches figma/css")
                 {
-                    g.fillAll (juce::Colours::white);
-                    // offset larger than radius, so we can't pull pixels from the single chan blur anymore
-                    shadow = { { juce::Colours::white, 2, { 3, 0 } } };
-                    g.setColour (juce::Colours::black);
-                    g.fillPath (p);
+                    {
+                        juce::Graphics g (result);
+                        g.fillAll (juce::Colours::white);
+                        g.fillAll (juce::Colours::white);
+                        // offset larger than radius, so we can't pull pixels from the single chan blur anymore
+                        shadow = { { juce::Colours::white, 2, { 3, 0 } } };
+                        g.setColour (juce::Colours::black);
+                        g.fillPath (p);
 
-                    // inner shadow render must come AFTER the path render
-                    shadow.render (g, p);
+                        // inner shadow render must come AFTER the path render
+                        shadow.render (g, p);
+                    }
 
                     save_test_image (result, "inner_shadow_2px_positive_offset_3");
 
@@ -230,14 +259,17 @@ TEST_CASE ("Melatonin Blur Inner Shadow")
 
                 SECTION ("negative")
                 {
-                    g.fillAll (juce::Colours::white);
-                    shadow = { { juce::Colours::white, 2, { -2, 0 } } };
-                    g.setColour (juce::Colours::black);
-                    g.fillPath (p);
+                    {
+                        juce::Graphics g (result);
+                        g.fillAll (juce::Colours::white);
+                        g.fillAll (juce::Colours::white);
+                        shadow = { { juce::Colours::white, 2, { -2, 0 } } };
+                        g.setColour (juce::Colours::black);
+                        g.fillPath (p);
 
-                    // inner shadow render must come AFTER the path render
-                    shadow.render (g, p);
-
+                        // inner shadow render must come AFTER the path render
+                        shadow.render (g, p);
+                    }
                     save_test_image (result, "inner_shadow_2px_negative_offset_x");
                     // inner right edge has more white
 
@@ -278,19 +310,25 @@ TEST_CASE ("Melatonin Blur Inner Shadow")
         // just show us one rounded corner
         // corners of 8 get us a very round corner
         rounded.addRoundedRectangle (-5, -5, 10, 10, 5);
-
-        g.fillAll (juce::Colours::white);
         melatonin::InnerShadow shadow = { { juce::Colours::white, 2 } };
-        g.setColour (juce::Colours::black);
-        g.fillPath (rounded);
 
-        auto cornerColorWithoutShadow = result.getPixelAt (4, 4).getBrightness();
+        float cornerColorWithoutShadow;
+
+        {
+            juce::Graphics g (result);
+            g.fillAll (juce::Colours::white);
+            g.setColour (juce::Colours::black);
+            g.fillPath (rounded);
+        }
+        cornerColorWithoutShadow = result.getPixelAt (4, 4).getBrightness();
         CHECK (cornerColorWithoutShadow == Catch::Approx (1.0f));
 
-        // inner shadow render must come AFTER the path render
-        shadow.render (g, rounded);
+        {
+            juce::Graphics g (result);
 
-        save_test_image (result, "inner_shadow_2px_clipped");
+            // inner shadow render must come AFTER the path render
+            shadow.render (g, rounded);
+        }
 
         SECTION ("corner still white")
         {

--- a/tests/juce_context_transforms.cpp
+++ b/tests/juce_context_transforms.cpp
@@ -17,7 +17,6 @@ TEST_CASE ("Melatonin Blur JUCE sanity checks")
         // the image bounds backing our temporary context must be able to contain the transformed image
         // here we will work in 4x4, it will be transformed by the context to 8x8
         juce::Image image (juce::Image::PixelFormat::ARGB, 8, 8, true);
-        juce::Image::BitmapData data (image, juce::Image::BitmapData::readOnly);
 
         // create a 4x4 rectangle
         juce::Path p;
@@ -34,7 +33,7 @@ TEST_CASE ("Melatonin Blur JUCE sanity checks")
         }
 
         save_test_image(image, "path_drawing_respects_context_scale");
-
+        juce::Image::BitmapData data (image, juce::Image::BitmapData::readOnly);
         CHECK(image.getPixelAt(0, 0).toString() == juce::Colours::lime.toString());
         CHECK(data.getPixelColour (0,0) == juce::Colours::lime);
         CHECK(data.getPixelColour (0,0).toString() == juce::Colours::lime.toString());

--- a/tests/juce_context_transforms.cpp
+++ b/tests/juce_context_transforms.cpp
@@ -19,17 +19,19 @@ TEST_CASE ("Melatonin Blur JUCE sanity checks")
         juce::Image image (juce::Image::PixelFormat::ARGB, 8, 8, true);
         juce::Image::BitmapData data (image, juce::Image::BitmapData::readOnly);
 
-        // create our new context
-        juce::Graphics g2 (image);
-        g2.addTransform (juce::AffineTransform::scale (scaleFactor));
-
         // create a 4x4 rectangle
         juce::Path p;
         p.addRectangle (juce::Rectangle<float> (4, 4));
 
-        // draw the rectangle
-        g2.setColour (juce::Colours::lime);
-        g2.fillPath (p);
+        {
+            // create our new context
+            juce::Graphics g2 (image);
+            g2.addTransform (juce::AffineTransform::scale (scaleFactor));
+
+            // draw the rectangle
+            g2.setColour (juce::Colours::lime);
+            g2.fillPath (p);
+        }
 
         save_test_image(image, "path_drawing_respects_context_scale");
 
@@ -48,17 +50,19 @@ TEST_CASE ("Melatonin Blur JUCE sanity checks")
         // our source will be 4x4, transformed by the context to 8x8
         juce::Image simulated2xContext (juce::Image::PixelFormat::ARGB, 8, 8, true);
 
-        juce::Graphics g (simulated2xContext);
-        g.addTransform (juce::AffineTransform::scale (scaleFactor));
+        {
+            juce::Graphics g (simulated2xContext);
+            g.addTransform (juce::AffineTransform::scale (scaleFactor));
 
-        // simulate creating a normal 4x4 image
-        // for example, our "lowQuality" drop shadows do this behind the scenes
-        juce::Image source (juce::Image::PixelFormat::ARGB, 4, 4, true);
-        juce::Graphics g2 (source);
-        g2.setColour (juce::Colours::lime);
-        g2.fillAll();
+            // simulate creating a normal 4x4 image
+            // for example, our "lowQuality" drop shadows do this behind the scenes
+            juce::Image source (juce::Image::PixelFormat::ARGB, 4, 4, true);
+            juce::Graphics g2 (source);
+            g2.setColour (juce::Colours::lime);
+            g2.fillAll();
 
-        g.drawImageAt (source, 0, 0, false);
+            g.drawImageAt (source, 0, 0, false);
+        }
 
         save_test_image (simulated2xContext, "simulated2xcontext");
 
@@ -74,20 +78,23 @@ TEST_CASE ("Melatonin Blur JUCE sanity checks")
         // our source will be 4x4, transformed by the context to 8x8
         juce::Image simulated2xContext (juce::Image::PixelFormat::ARGB, 8, 8, true);
 
-        juce::Graphics g (simulated2xContext);
-        g.addTransform (juce::AffineTransform::scale (scaleFactor));
+        {
+            juce::Graphics g (simulated2xContext);
+            g.addTransform (juce::AffineTransform::scale (scaleFactor));
 
-        // simulate creating a 8x8 image, like our high quality blurs do
-        juce::Image source (juce::Image::PixelFormat::ARGB, 8, 8, true);
-        juce::Graphics g2 (source);
+            // simulate creating a 8x8 image, like our high quality blurs do
+            juce::Image source (juce::Image::PixelFormat::ARGB, 8, 8, true);
+            juce::Graphics g2 (source);
 
-        // the transforms on source and target match
-        g2.addTransform (juce::AffineTransform::scale (scaleFactor));
-        g2.setColour (juce::Colours::lime);
-        g2.fillAll();
+            // the transforms on source and target match
+            g2.addTransform (juce::AffineTransform::scale (scaleFactor));
+            g2.setColour (juce::Colours::lime);
+            g2.fillAll();
 
-        // TODO: I wonder if JUCE's drawImageAt could be cheaper if the transforms were compared?
-        g.drawImageAt (source, 0, 0, false);
+
+            // TODO: I wonder if JUCE's drawImageAt could be cheaper if the transforms were compared?
+            g.drawImageAt (source, 0, 0, false);
+        }
 
         // confirm the entire 8x8 is filled
         CHECK (isImageFilled (simulated2xContext, juce::Colours::lime) == true);

--- a/tests/path_with_shadows.cpp
+++ b/tests/path_with_shadows.cpp
@@ -26,8 +26,6 @@ TEST_CASE ("Melatonin Blur PathWithShadows")
     juce::ScopedJuceInitialiser_GUI juce;
 
     juce::Image result (juce::Image::ARGB, 9, 9, true);
-    juce::Graphics g (result);
-    g.fillAll (juce::Colours::white);
 
     melatonin::PathWithShadows p;
 
@@ -36,21 +34,33 @@ TEST_CASE ("Melatonin Blur PathWithShadows")
 
     SECTION ("renders the path")
     {
-        p.render (g);
+        {
+            juce::Graphics g (result);
+            g.fillAll (juce::Colours::white);
+            p.render (g);
+        }
         CHECK (filledBounds (result).toString() == juce::Rectangle<int> (3, 3, 3, 3).toString());
     }
 
     SECTION ("renders a 1px drop shadow")
     {
         p.dropShadow.setColor (juce::Colours::red).setRadius (1);
-        p.render (g);
+        {
+            juce::Graphics g (result);
+            g.fillAll (juce::Colours::white);
+            p.render (g);
+        }
         CHECK (filledBounds (result).toString() == juce::Rectangle<int> (2, 2, 5, 5).toString());
     }
 
     SECTION ("path renders in front of drop shadow")
     {
         p.dropShadow.setColor (juce::Colours::red).setRadius (1);
-        p.render (g);
+        {
+            juce::Graphics g (result);
+            g.fillAll (juce::Colours::white);
+            p.render (g);
+        }
 
         // check for the black square
         CHECK (getPixels (result, 3, { 3, 5 }) == "FF000000, FF000000, FF000000");
@@ -60,7 +70,11 @@ TEST_CASE ("Melatonin Blur PathWithShadows")
     SECTION ("1px inner shadow")
     {
         p.innerShadow.setColor (juce::Colours::red).setRadius (1);
-        p.render (g);
+        {
+            juce::Graphics g (result);
+            g.fillAll (juce::Colours::white);
+            p.render (g);
+        }
 
         // still is 3x3
         CHECK (filledBounds (result).toString() == juce::Rectangle<int> (3, 3, 3, 3).toString());

--- a/tests/shadow_scaling.cpp
+++ b/tests/shadow_scaling.cpp
@@ -190,7 +190,6 @@ TEST_CASE ("Melatonin Blur Shadow Scaling")
                 }
                 save_test_image (noScale, "noscalerender");
                 auto firstPixelBrightness = getScaledBrightness (noScale, 1, 4, 1.0f);
-                auto secondPixelBrightness = getScaledBrightness (noScale, 2, 4, 1.0f);
 
                 SECTION ("logical radius 2, scale 2, lofi")
                 {

--- a/tests/shadow_scaling.cpp
+++ b/tests/shadow_scaling.cpp
@@ -27,22 +27,23 @@ TEST_CASE ("Melatonin Blur Shadow Scaling")
     p.addRectangle (bounds.translated (3, 3));
 
     // needed for JUCE not to pee its pants (aka leak) when working with graphics
-    juce::ScopedJuceInitialiser_GUI juce;
+    juce::ScopedJuceInitialiser_GUI gui;
 
     SECTION ("scaling")
     {
         SECTION ("default scaling (tests not running on a screen) is 1.0")
         {
             juce::Image result (juce::Image::ARGB, 9, 9, true);
-            juce::Graphics g (result);
-            g.fillAll (juce::Colours::white);
+            {
+                juce::Graphics g (result);
+                g.fillAll (juce::Colours::white);
 
-            // offset by 1px to the right/bottom
-            melatonin::DropShadow shadow = { { juce::Colours::black, 1 } };
-            shadow.render (g, p);
-            g.setColour (juce::Colours::black);
-            g.fillPath (p);
-
+                // offset by 1px to the right/bottom
+                melatonin::DropShadow shadow = { { juce::Colours::black, 1 } };
+                shadow.render (g, p);
+                g.setColour (juce::Colours::black);
+                g.fillPath (p);
+            }
             save_test_image (result, "at1x");
 
             // 2 lines of white pixels on all edges
@@ -87,9 +88,11 @@ TEST_CASE ("Melatonin Blur Shadow Scaling")
                     auto contextWidth = juce::roundToInt (9 * scale);
                     auto contextHeight = juce::roundToInt (9 * scale);
                     juce::Image result (juce::Image::ARGB, contextWidth, contextHeight, true);
-                    juce::Graphics g (result);
-                    g.addTransform (juce::AffineTransform::scale (scale));
-                    g.fillAll (juce::Colours::white);
+                    {
+                        juce::Graphics g (result);
+                        g.addTransform (juce::AffineTransform::scale (scale));
+                        g.fillAll (juce::Colours::white);
+                    }
 
                     SECTION ("radius 1")
                     {
@@ -100,33 +103,36 @@ TEST_CASE ("Melatonin Blur Shadow Scaling")
 
                             // all path coordinates upscaled on draw
                             // example: the origin 3,3 will be 12,12 for @4x
-                            shadow.render (g, p);
-                            g.setColour (juce::Colours::black);
-                            g.fillPath (p);
-
+                            {
+                                juce::Graphics g (result);
+                                g.addTransform (juce::AffineTransform::scale (scale));
+                                shadow.render (g, p);
+                                g.setColour (juce::Colours::black);
+                                g.fillPath (p);
+                            }
                             save_test_image (result, "at2xbaybee");
 
                             SECTION ("2 outer edges white")
                             {
                                 // left
-                                CHECK (getScaledBrightness (result, 0, 4, scale) == Catch::Approx (1.0f));
-                                CHECK (getScaledBrightness (result, 1, 4, scale) == Catch::Approx (1.0f));
-                                CHECK (getScaledBrightness (result, 2, 4, scale) != Catch::Approx (1.0f));
+                                CHECK (getScaledBrightness (result, 0, 4, scale) == Catch::Approx (1.0f).margin(0.001));
+                                CHECK (getScaledBrightness (result, 1, 4, scale) == Catch::Approx (1.0f).margin(0.001));
+                                CHECK (getScaledBrightness (result, 2, 4, scale) != Catch::Approx (1.0f).margin(0.001));
 
                                 // top
-                                CHECK (getScaledBrightness (result, 4, 0, scale) == Catch::Approx (1.0f));
-                                CHECK (getScaledBrightness (result, 4, 1, scale) == Catch::Approx (1.0f));
-                                CHECK (getScaledBrightness (result, 4, 2, scale) != Catch::Approx (1.0f));
+                                CHECK (getScaledBrightness (result, 4, 0, scale) == Catch::Approx (1.0f).margin(0.001));
+                                CHECK (getScaledBrightness (result, 4, 1, scale) == Catch::Approx (1.0f).margin(0.001));
+                                CHECK (getScaledBrightness (result, 4, 2, scale) != Catch::Approx (1.0f).margin(0.001));
 
                                 // right
-                                CHECK (getScaledBrightness (result, 8, 4, scale) == Catch::Approx (1.0f));
-                                CHECK (getScaledBrightness (result, 7, 4, scale) == Catch::Approx (1.0f));
-                                CHECK (getScaledBrightness (result, 6, 4, scale) != Catch::Approx (1.0f));
+                                CHECK (getScaledBrightness (result, 8, 4, scale) == Catch::Approx (1.0f).margin(0.001));
+                                CHECK (getScaledBrightness (result, 7, 4, scale) == Catch::Approx (1.0f).margin(0.001));
+                                CHECK (getScaledBrightness (result, 6, 4, scale) != Catch::Approx (1.0f).margin(0.001));
 
                                 // bottom
-                                CHECK (getScaledBrightness (result, 4, 8, scale) == Catch::Approx (1.0f));
-                                CHECK (getScaledBrightness (result, 4, 7, scale) == Catch::Approx (1.0f));
-                                CHECK (getScaledBrightness (result, 4, 6, scale) != Catch::Approx (1.0f));
+                                CHECK (getScaledBrightness (result, 4, 8, scale) == Catch::Approx (1.0f).margin(0.001));
+                                CHECK (getScaledBrightness (result, 4, 7, scale) == Catch::Approx (1.0f).margin(0.001));
+                                CHECK (getScaledBrightness (result, 4, 6, scale) != Catch::Approx (1.0f).margin(0.001));
                             }
                         }
 
@@ -137,10 +143,13 @@ TEST_CASE ("Melatonin Blur Shadow Scaling")
                             melatonin::DropShadow shadow = { { juce::Colours::black, 1, {}, 0 } };
 
                             // passing true here renders low quality!
-                            shadow.render (g, p, true);
-                            g.setColour (juce::Colours::black);
-                            g.fillPath (p);
-
+                            {
+                                juce::Graphics g (result);
+                                g.addTransform (juce::AffineTransform::scale (scale));
+                                shadow.render (g, p, true);
+                                g.setColour (juce::Colours::black);
+                                g.fillPath (p);
+                            }
                             save_test_image (result, "at2xlofi");
 
                             // left
@@ -171,13 +180,14 @@ TEST_CASE ("Melatonin Blur Shadow Scaling")
             {
                 // render an unscaled shadow as reference
                 juce::Image noScale (juce::Image::ARGB, 9, 9, true);
-                juce::Graphics g2 (noScale);
-                g2.fillAll (juce::Colours::white);
-                melatonin::DropShadow noScaleShadow = { { juce::Colours::black, 2 } };
-                noScaleShadow.render (g2, p);
-                g2.setColour (juce::Colours::black);
-                g2.fillPath(p);
-
+                {
+                    juce::Graphics g2 (noScale);
+                    g2.fillAll (juce::Colours::white);
+                    melatonin::DropShadow noScaleShadow = { { juce::Colours::black, 2 } };
+                    noScaleShadow.render (g2, p);
+                    g2.setColour (juce::Colours::black);
+                    g2.fillPath (p);
+                }
                 save_test_image (noScale, "noscalerender");
                 auto firstPixelBrightness = getScaledBrightness (noScale, 1, 4, 1.0f);
                 auto secondPixelBrightness = getScaledBrightness (noScale, 2, 4, 1.0f);
@@ -188,16 +198,18 @@ TEST_CASE ("Melatonin Blur Shadow Scaling")
                     auto contextWidth = juce::roundToInt (9 * scale);
                     auto contextHeight = juce::roundToInt (9 * scale);
                     juce::Image result (juce::Image::ARGB, contextWidth, contextHeight, true);
-                    juce::Graphics g (result);
-                    g.addTransform (juce::AffineTransform::scale (scale));
-                    g.fillAll (juce::Colours::white);
-
                     melatonin::DropShadow shadow = { { juce::Colours::black, 2 } };
 
-                    // lowQuality! this OS will render up the image to 2x
-                    shadow.render (g, p, true);
-                    g.setColour (juce::Colours::black);
-                    g.fillPath (p);
+                    {
+                        juce::Graphics g (result);
+                        g.addTransform (juce::AffineTransform::scale (scale));
+                        g.fillAll (juce::Colours::white);
+
+                        // lowQuality! this OS will render up the image to 2x
+                        shadow.render (g, p, true);
+                        g.setColour (juce::Colours::black);
+                        g.fillPath (p);
+                    }
 
                     save_test_image(result, "2pxlofi");
 
@@ -233,16 +245,18 @@ TEST_CASE ("Melatonin Blur Shadow Scaling")
                     auto contextWidth = juce::roundToInt (9 * scale);
                     auto contextHeight = juce::roundToInt (9 * scale);
                     juce::Image result (juce::Image::ARGB, contextWidth, contextHeight, true);
-                    juce::Graphics g (result);
-                    g.addTransform (juce::AffineTransform::scale (scale));
-                    g.fillAll (juce::Colours::white);
-
                     melatonin::DropShadow shadow = { { juce::Colours::black, 2 } };
 
-                    // HIGH QUALITY!
-                    shadow.render (g, p);
-                    g.setColour (juce::Colours::black);
-                    g.fillPath (p);
+                    {
+                        juce::Graphics g (result);
+                        g.addTransform (juce::AffineTransform::scale (scale));
+                        g.fillAll (juce::Colours::white);
+
+                        // HIGH QUALITY!
+                        shadow.render (g, p);
+                        g.setColour (juce::Colours::black);
+                        g.fillPath (p);
+                    }
 
                     save_test_image (result, "2pxhighquality");
 
@@ -280,17 +294,20 @@ TEST_CASE ("Melatonin Blur Shadow Scaling")
             auto contextWidth = juce::roundToInt (9 * scale);
             auto contextHeight = juce::roundToInt (9 * scale);
             juce::Image result (juce::Image::ARGB, contextWidth, contextHeight, true);
-            juce::Graphics g (result);
-            g.addTransform (juce::AffineTransform::scale (scale));
-            g.fillAll (juce::Colours::white);
+
 
             // technically shadows will be a bit stronger at x.5 scale
             SECTION ("1.5x the radius of 1 rounds UP to a radius of 2")
             {
                 melatonin::DropShadow shadow = { { juce::Colours::black, 1 } };
-                shadow.render (g, p);
-                g.setColour (juce::Colours::black);
-                g.fillPath (p);
+                {
+                    juce::Graphics g (result);
+                    g.addTransform (juce::AffineTransform::scale (scale));
+                    g.fillAll (juce::Colours::white);
+                    shadow.render (g, p);
+                    g.setColour (juce::Colours::black);
+                    g.fillPath (p);
+                }
 
                 // left
                 CHECK (getScaledBrightness (result, 0, 4, scale) == Catch::Approx (1.0f));
@@ -313,12 +330,17 @@ TEST_CASE ("Melatonin Blur Shadow Scaling")
             {
                 // this now behaves as if the radius is 3
                 melatonin::DropShadow shadow = { { juce::Colours::black, 2 } };
-                shadow.render (g, p);
-                g.setColour (juce::Colours::black);
+                {
+                    juce::Graphics g (result);
+                    g.addTransform (juce::AffineTransform::scale (scale));
+                    g.fillAll (juce::Colours::white);
 
-                // this will have an origin of [4.5, 4.5] and a width of 4.5
-                g.fillPath (p);
+                    shadow.render (g, p);
+                    g.setColour (juce::Colours::black);
 
+                    // this will have an origin of [4.5, 4.5] and a width of 4.5
+                    g.fillPath (p);
+                }
                 // due to subpixel rendering, our blur image is 14px
                 // On the left / top, we are blurring a bit more than 3px away from 4.5 (path's left x)
                 // On the right, we are blurring a bit more than 3px away from 9 (path's right x)
@@ -354,9 +376,6 @@ TEST_CASE ("Melatonin Blur Shadow Scaling")
         auto contextWidth = juce::roundToInt (9);
         auto contextHeight = juce::roundToInt (9);
         juce::Image result (juce::Image::ARGB, contextWidth, contextHeight, true);
-        juce::Graphics g (result);
-
-        g.fillAll (juce::Colours::white);
 
         SECTION ("user scales up")
         {
@@ -364,9 +383,14 @@ TEST_CASE ("Melatonin Blur Shadow Scaling")
 
             // this still behaves as if the radius is 2
             melatonin::DropShadow shadow = { { juce::Colours::black, 2 } };
-            shadow.render (g, p);
-            g.setColour (juce::Colours::black);
-            g.fillPath (p);
+            {
+                juce::Graphics g (result);
+                g.fillAll (juce::Colours::white);
+
+                shadow.render (g, p);
+                g.setColour (juce::Colours::black);
+                g.fillPath (p);
+            }
 
             // left
             CHECK (result.getPixelAt (0, 4).getBrightness() == Catch::Approx (1.0f));
@@ -391,10 +415,14 @@ TEST_CASE ("Melatonin Blur Shadow Scaling")
 
             // this now behaves as if the radius is 2
             melatonin::DropShadow shadow = { { juce::Colours::black, 2 } };
-            shadow.render (g, p);
-            g.setColour (juce::Colours::black);
-            g.fillPath (p);
+            {
+                juce::Graphics g (result);
+                g.fillAll (juce::Colours::white);
 
+                shadow.render (g, p);
+                g.setColour (juce::Colours::black);
+                g.fillPath (p);
+            }
             // left
             CHECK (result.getPixelAt (0, 4).getBrightness() == Catch::Approx (1.0f));
             CHECK (result.getPixelAt (1, 4).getBrightness() == Catch::Approx (0.91373f).margin (0.05f));

--- a/tests/stroked_path.cpp
+++ b/tests/stroked_path.cpp
@@ -115,10 +115,11 @@ TEST_CASE ("Melatonin Blur Stroked Path")
         {
             juce::Graphics g (result);
             shadow.render (g, p, strokeType);
-            CHECK (getPixel (result, 2, 6) != "FF000000");
-            CHECK (getPixel (result, 3, 5) != "FF000000");
-            CHECK (getPixel (result, 4, 4) != "FF000000");
         }
+        CHECK (getPixel (result, 2, 6) != "FF000000");
+        CHECK (getPixel (result, 3, 5) != "FF000000");
+        CHECK (getPixel (result, 4, 4) != "FF000000");
+
         save_test_image (result, "stroked_path_inner.png");
     }
 }

--- a/tests/stroked_path.cpp
+++ b/tests/stroked_path.cpp
@@ -30,14 +30,16 @@ TEST_CASE ("Melatonin Blur Stroked Path")
     juce::ScopedJuceInitialiser_GUI juce;
 
     juce::Image result (juce::Image::ARGB, 9, 9, true);
-    juce::Graphics g (result);
 
     // TODO: sorta surprised this doesn't stroke the center by default, JUCE?
     SECTION ("no shadow")
     {
-        g.fillAll (juce::Colours::white);
-        auto strokeType = juce::PathStrokeType (2.0f);
-        g.strokePath (p, strokeType);
+        {
+            juce::Graphics g (result);
+            g.fillAll (juce::Colours::white);
+            auto strokeType = juce::PathStrokeType (2.0f);
+            g.strokePath (p, strokeType);
+        }
 
         // the top left corner is all white
         CHECK (getPixels (result, { 0, 1 }, { 0, 1 }) == "FFFFFFFF, FFFFFFFF, FFFFFFFF, FFFFFFFF");
@@ -49,12 +51,14 @@ TEST_CASE ("Melatonin Blur Stroked Path")
     // this doesn't test shadow details, just that the API works :)
     SECTION ("drop shadow with stroke of 2")
     {
-        g.fillAll (juce::Colours::white);
-        melatonin::DropShadow shadow (juce::Colours::black, 2);
-        auto strokeType = juce::PathStrokeType (3.0f);
-        shadow.render (g, p, strokeType);
-        g.strokePath (p, strokeType);
-
+        {
+            juce::Graphics g (result);
+            g.fillAll (juce::Colours::white);
+            melatonin::DropShadow shadow (juce::Colours::black, 2);
+            auto strokeType = juce::PathStrokeType (3.0f);
+            shadow.render (g, p, strokeType);
+            g.strokePath (p, strokeType);
+        }
         save_test_image (result, "stroked_path.png");
 
         // the top left corner is no longer white
@@ -66,40 +70,55 @@ TEST_CASE ("Melatonin Blur Stroked Path")
 
     SECTION ("changing stroke type breaks cache")
     {
-        g.fillAll (juce::Colours::white);
         melatonin::DropShadow shadow (juce::Colours::black, 2);
         auto strokeType = juce::PathStrokeType (3.0f);
-        shadow.render (g, p, strokeType);
 
-        // erase the image, render the shadow again
-        g.fillAll (juce::Colours::white);
-        strokeType = juce::PathStrokeType (0.0f);
-        shadow.render (g, p, strokeType);
+        {
+            juce::Graphics g (result);
+            g.fillAll (juce::Colours::white);
+            shadow.render (g, p, strokeType);
 
-        // there should be no more shadow (and we didn't render the path, so pure white)
+            // erase the image, render the shadow again
+            g.fillAll (juce::Colours::white);
+            strokeType = juce::PathStrokeType (0.0f);
+            shadow.render (g, p, strokeType);
+        }
+
+        // there should be no shadow (we didn't render the path, so pure white)
         CHECK (filledBounds (result).isEmpty());
 
         // erase the image, render the shadow again
-        g.fillAll (juce::Colours::white);
-        strokeType = juce::PathStrokeType (1.0f);
-        shadow.render (g, p, strokeType);
+        {
+            juce::Graphics g (result);
+            g.fillAll (juce::Colours::white);
+            strokeType = juce::PathStrokeType (1.0f);
+            shadow.render (g, p, strokeType);
+        }
 
         CHECK (!filledBounds (result).isEmpty());
     }
 
     SECTION ("inner shadow")
     {
-        g.fillAll (juce::Colours::white);
         melatonin::InnerShadow shadow (juce::Colours::white, 1);
         auto strokeType = juce::PathStrokeType (3.0f);
-        g.strokePath (p, strokeType);
+
+        {
+            juce::Graphics g (result);
+            g.fillAll (juce::Colours::white);
+            g.strokePath (p, strokeType);
+        }
         CHECK (getPixel (result, 2, 6) == "FF000000");
         CHECK (getPixel (result, 3, 5) == "FF000000");
         CHECK (getPixel (result, 4, 4) == "FF000000");
-        shadow.render (g, p, strokeType);
-        CHECK (getPixel (result, 2, 6) != "FF000000");
-        CHECK (getPixel (result, 3, 5) != "FF000000");
-        CHECK (getPixel (result, 4, 4) != "FF000000");
+
+        {
+            juce::Graphics g (result);
+            shadow.render (g, p, strokeType);
+            CHECK (getPixel (result, 2, 6) != "FF000000");
+            CHECK (getPixel (result, 3, 5) != "FF000000");
+            CHECK (getPixel (result, 4, 4) != "FF000000");
+        }
         save_test_image (result, "stroked_path_inner.png");
     }
 }

--- a/tests/text_shadow.cpp
+++ b/tests/text_shadow.cpp
@@ -27,31 +27,40 @@ TEST_CASE ("Melatonin Blur Text Shadow")
     juce::ScopedJuceInitialiser_GUI juce;
 
     juce::Image result (juce::Image::ARGB, 9, 9, true);
-    juce::Graphics g (result);
 
     SECTION ("no shadow")
     {
-        g.fillAll (juce::Colours::white);
-        g.setColour (juce::Colours::black);
-        g.drawText ("O", 0, 0, 9, 9, juce::Justification::centred, false);
+        {
+            juce::Graphics g (result);
+            g.fillAll (juce::Colours::white);
+            g.setColour (juce::Colours::black);
+            g.setFont(g.getCurrentFont().withHeight(13));
+            g.drawText ("O", 0, 0, 9, 9, juce::Justification::centred, false);
+        }
 
+        save_test_image (result, "text_no_shadow.png");
         // middle of image is white
         CHECK (result.getPixelAt (4, 4).toDisplayString (true) == "FFFFFFFF");
 
         // top middle is close to black
         auto topMiddle = result.getPixelAt (4, 4);
-        CHECK (getPixel (result, 4, 0) != "FFFFFFFF");
+        CHECK (getPixel (result, 4, 1) != "FFFFFFFF");
         CHECK (topMiddle.getRed() == topMiddle.getGreen());
     }
 
     // not testing mechanics/details of drop shadow here, just that API worked
     SECTION ("drop shadow")
     {
-        g.fillAll (juce::Colours::white);
-        melatonin::DropShadow shadow (juce::Colours::black, 3);
-        g.setColour (juce::Colours::black);
-        shadow.render (g, "O", 0, 0, 9, 9, juce::Justification::centred);
-        g.drawText ("O", 0, 0, 9, 9, juce::Justification::centred, false);
+        {
+            juce::Graphics g (result);
+
+            g.fillAll (juce::Colours::white);
+            melatonin::DropShadow shadow (juce::Colours::black, 3);
+            g.setColour (juce::Colours::black);
+            g.setFont(g.getCurrentFont().withHeight(13));
+            shadow.render (g, "O", 0, 0, 9, 9, juce::Justification::centred);
+            g.drawText ("O", 0, 0, 9, 9, juce::Justification::centred, false);
+        }
 
         // middle of image is no longer white
         CHECK (result.getPixelAt (4, 4).toDisplayString (true) != "FFFFFFFF");
@@ -60,25 +69,32 @@ TEST_CASE ("Melatonin Blur Text Shadow")
 
     SECTION ("inner shadow")
     {
-        g.fillAll (juce::Colours::white);
-        melatonin::InnerShadow shadow (juce::Colours::red, 1);
-        g.setColour (juce::Colours::black);
-        g.drawText ("O", 0, 0, 9, 9, juce::Justification::centred, false);
-        shadow.render (g, "O", 0, 0, 9, 9, juce::Justification::centred);
+        {
+            juce::Graphics g (result);
+            g.fillAll (juce::Colours::white);
+            melatonin::InnerShadow shadow (juce::Colours::red, 1);
+            g.setColour (juce::Colours::black);
+            g.setFont(g.getCurrentFont().withHeight(13));
+            g.drawText ("O", 0, 0, 9, 9, juce::Justification::centred, false);
+            shadow.render (g, "O", 0, 0, 9, 9, juce::Justification::centred);
+        }
 
         // top middle has more red than green
-        auto topMiddle = result.getPixelAt (4, 0);
+        auto topMiddle = result.getPixelAt (4, 1);
         CHECK (topMiddle.getRed() > topMiddle.getGreen());
         save_test_image (result, "text_inner_shadow.png");
     }
 
     SECTION ("accepts permutations of rectangle")
     {
-        melatonin::InnerShadow shadow (juce::Colours::red, 1);
-        shadow.render (g, "O", 0, 0, 9, 9, juce::Justification::centred);
-        juce::Rectangle<int> intRect (0, 0, 9, 9);
-        shadow.render (g, "O", intRect, juce::Justification::centred);
-        juce::Rectangle<float> floatRect (0, 0, 9, 9);
-        shadow.render (g, "O", floatRect, juce::Justification::centred);
+        {
+            juce::Graphics g (result);
+            melatonin::InnerShadow shadow (juce::Colours::red, 1);
+            shadow.render (g, "O", 0, 0, 9, 9, juce::Justification::centred);
+            juce::Rectangle<int> intRect (0, 0, 9, 9);
+            shadow.render (g, "O", intRect, juce::Justification::centred);
+            juce::Rectangle<float> floatRect (0, 0, 9, 9);
+            shadow.render (g, "O", floatRect, juce::Justification::centred);
+        }
     }
 }

--- a/tests/text_shadow.cpp
+++ b/tests/text_shadow.cpp
@@ -34,13 +34,16 @@ TEST_CASE ("Melatonin Blur Text Shadow")
             juce::Graphics g (result);
             g.fillAll (juce::Colours::white);
             g.setColour (juce::Colours::black);
-            g.setFont(g.getCurrentFont().withHeight(13));
+            g.setFont(g.getCurrentFont().withHeight(12)); // macos and windows happy with 13, ubuntu needs 12
             g.drawText ("O", 0, 0, 9, 9, juce::Justification::centred, false);
         }
 
         save_test_image (result, "text_no_shadow.png");
         // middle of image is white
         CHECK (result.getPixelAt (4, 4).toDisplayString (true) == "FFFFFFFF");
+
+        // whole image isn't white
+        CHECK (isImageFilled (result, juce::Colours::white) != true);
 
         // top middle is close to black
         auto topMiddle = result.getPixelAt (4, 4);


### PR DESCRIPTION
**Don't merge** Seems like CI is always running JUCE 8, gotta look into it...

This ended up being a pretty big PR.

* Adds support for JUCE 8, fixing graphics context D2D issues (see below)
* Runs tests and benchmarks on JUCE 7 and JUCE 8
* Adds tests on Ubuntu and Windows 2019
* Runs tests and benchmarks separately (vs. together via ctest)
* Turn on COMPILE_WARNING_AS_ERROR 

---

See the JUCE forum thread for details on the upgrades needed for JUCE 8: https://forum.juce.com/t/juce-8-direct2d-melatonin-blur-issue/61758

The main issue here is with JUCE 8's default Windows rendered, Direct2D (like OpenGL) won't update the image  from the GPU until the graphics object goes out of scope. 

Translation: Anytime we create graphics objects, if we want to see the result, they have to be in their own scope.

