### PR TITLE
macos-11 is no longer reliable on GA

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false # show errors for each platform vs. cancel build
       matrix:
-        os: [ macos-11, macos-12, macos-13, macos-14, windows-2022, windows-2019, ubuntu-20.04, ubuntu-latest ]
+        os: [ macos-12, macos-13, macos-14, windows-2022, windows-2019, ubuntu-20.04, ubuntu-latest ]
         juce: [ JUCE7, JUCE8 ]
 
     steps:


### PR DESCRIPTION
https://github.com/actions/runner-images/commit/5418817c5fd272379f7d5a56c2e63a3d7f1a49d8