### PR TITLE
Specify C and CXX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.20)
 
-project(MelatoninBlur VERSION 1.0.0 LANGUAGES CXX
+project(MelatoninBlur VERSION 1.0.0 LANGUAGES C CXX
         DESCRIPTION "Fast Blurs for JUCE"
         HOMEPAGE_URL "https://github.com/sudara/melatonin_blur")
 


### PR DESCRIPTION
Something in JUCE 8.0.2 now requires `LANGUAGES C` to be set, not just `CXX`

Without this change, the following error occurs:

```
CMake Error: Error required internal CMake variable not set, cmake may not be built correctly.
Missing variable is:
CMAKE_C_COMPILE_OBJECT
```