### PR TITLE
Add float constructors and setters. Fix setters caching bug.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -27,6 +27,8 @@ BraceWrapping: # Allman except for lambdas
   AfterClass: true
   AfterCaseLabel: true
   AfterFunction: true
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
   AfterNamespace: true
   AfterStruct: true
   BeforeElse: true

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ You can specify the color, radius, offset and spread of each blur, passing them 
 
 ```cpp
 
-struct ShadowParameters
+struct ShadowParametersInt
 {
     // one single color per shadow
     juce::Colour color = juce::Colours::black;

--- a/melatonin/blur_demo_component.h
+++ b/melatonin/blur_demo_component.h
@@ -52,22 +52,22 @@ namespace melatonin
             opacitySlider.setValue (1);
 
             radiusSlider.onValueChange = [this] {
-                dropShadow.setRadius ((size_t) radiusSlider.getValue());
-                innerShadow.setRadius ((size_t) radiusSlider.getValue());
-                strokedDropShadow.setRadius ((size_t) radiusSlider.getValue());
-                strokedInnerShadow.setRadius ((size_t) radiusSlider.getValue());
-                textDropShadow.setRadius ((size_t) radiusSlider.getValue());
-                textInnerShadow.setRadius ((size_t) radiusSlider.getValue());
+                dropShadow.setRadius (radiusSlider.getValue());
+                innerShadow.setRadius (radiusSlider.getValue());
+                strokedDropShadow.setRadius (radiusSlider.getValue());
+                strokedInnerShadow.setRadius (radiusSlider.getValue());
+                textDropShadow.setRadius (radiusSlider.getValue());
+                textInnerShadow.setRadius (radiusSlider.getValue());
                 repaint();
             };
 
             spreadSlider.onValueChange = [this] {
-                dropShadow.setSpread ((size_t) spreadSlider.getValue());
-                innerShadow.setSpread ((size_t) spreadSlider.getValue());
-                strokedDropShadow.setSpread ((size_t) spreadSlider.getValue());
-                strokedInnerShadow.setSpread ((size_t) spreadSlider.getValue());
-                textDropShadow.setSpread ((size_t) spreadSlider.getValue());
-                textInnerShadow.setSpread ((size_t) spreadSlider.getValue());
+                dropShadow.setSpread (spreadSlider.getValue());
+                innerShadow.setSpread (spreadSlider.getValue());
+                strokedDropShadow.setSpread (spreadSlider.getValue());
+                strokedInnerShadow.setSpread (spreadSlider.getValue());
+                textDropShadow.setSpread (spreadSlider.getValue());
+                textInnerShadow.setSpread (spreadSlider.getValue());
                 repaint();
             };
 
@@ -92,12 +92,12 @@ namespace melatonin
             };
 
             opacitySlider.onValueChange = [this] {
-                dropShadow.setOpacity ((float) opacitySlider.getValue());
-                innerShadow.setOpacity ((float) opacitySlider.getValue());
-                strokedDropShadow.setOpacity ((float) opacitySlider.getValue());
-                strokedInnerShadow.setOpacity ((float) opacitySlider.getValue());
-                textDropShadow.setOpacity ((float) opacitySlider.getValue());
-                textInnerShadow.setOpacity ((float) opacitySlider.getValue());
+                dropShadow.setOpacity (opacitySlider.getValue());
+                innerShadow.setOpacity (opacitySlider.getValue());
+                strokedDropShadow.setOpacity (opacitySlider.getValue());
+                strokedInnerShadow.setOpacity (opacitySlider.getValue());
+                textDropShadow.setOpacity (opacitySlider.getValue());
+                textInnerShadow.setOpacity (opacitySlider.getValue());
                 repaint();
             };
 #if MELATONIN_VBLANK
@@ -276,11 +276,11 @@ namespace melatonin
         }
 
     private:
-        #if JUCE_MAJOR_VERSION >= 8
-        juce::Font font = juce::FontOptions {}.withName("Arial").withHeight (110.f).withStyle ("bold");
-        #else
+#if JUCE_MAJOR_VERSION >= 8
+        juce::Font font = juce::FontOptions {}.withName ("Arial").withHeight (110.f).withStyle ("bold");
+#else
         juce::Font font { "Arial", 110.f, juce::Font::bold };
-        #endif
+#endif
         melatonin::DropShadow dropShadow {
             { juce::Colour::fromRGB (196, 181, 157), 12, { 0, 13 } },
             { juce::Colours::white, 1, { 0, -2 } }

--- a/melatonin/blur_demo_component.h
+++ b/melatonin/blur_demo_component.h
@@ -72,22 +72,22 @@ namespace melatonin
             };
 
             offsetXSlider.onValueChange = [this] {
-                dropShadow.setOffset ({ (int) offsetXSlider.getValue(), (int) offsetYSlider.getValue() });
-                innerShadow.setOffset ({ (int) offsetXSlider.getValue(), (int) offsetYSlider.getValue() });
-                strokedDropShadow.setOffset ({ (int) offsetXSlider.getValue(), (int) offsetYSlider.getValue() });
-                strokedInnerShadow.setOffset ({ (int) offsetXSlider.getValue(), (int) offsetYSlider.getValue() });
-                textDropShadow.setOffset ({ (int) offsetXSlider.getValue(), (int) offsetYSlider.getValue() });
-                textInnerShadow.setOffset ({ (int) offsetXSlider.getValue(), (int) offsetYSlider.getValue() });
+                dropShadow.setOffset ({ offsetXSlider.getValue(), offsetYSlider.getValue() });
+                innerShadow.setOffset ({ offsetXSlider.getValue(), offsetYSlider.getValue() });
+                strokedDropShadow.setOffset ({ offsetXSlider.getValue(), offsetYSlider.getValue() });
+                strokedInnerShadow.setOffset ({ offsetXSlider.getValue(), offsetYSlider.getValue() });
+                textDropShadow.setOffset ({ offsetXSlider.getValue(), offsetYSlider.getValue() });
+                textInnerShadow.setOffset ({ offsetXSlider.getValue(), offsetYSlider.getValue() });
                 repaint();
             };
 
             offsetYSlider.onValueChange = [this] {
-                dropShadow.setOffset ({ (int) offsetXSlider.getValue(), (int) offsetYSlider.getValue() });
-                innerShadow.setOffset ({ (int) offsetXSlider.getValue(), (int) offsetYSlider.getValue() });
-                strokedDropShadow.setOffset ({ (int) offsetXSlider.getValue(), (int) offsetYSlider.getValue() });
-                strokedInnerShadow.setOffset ({ (int) offsetXSlider.getValue(), (int) offsetYSlider.getValue() });
-                textDropShadow.setOffset ({ (int) offsetXSlider.getValue(), (int) offsetYSlider.getValue() });
-                textInnerShadow.setOffset ({ (int) offsetXSlider.getValue(), (int) offsetYSlider.getValue() });
+                dropShadow.setOffset ({ offsetXSlider.getValue(), offsetYSlider.getValue() });
+                innerShadow.setOffset ({ offsetXSlider.getValue(), offsetYSlider.getValue() });
+                strokedDropShadow.setOffset ({ offsetXSlider.getValue(), offsetYSlider.getValue() });
+                strokedInnerShadow.setOffset ({ offsetXSlider.getValue(), offsetYSlider.getValue() });
+                textDropShadow.setOffset ({ offsetXSlider.getValue(), offsetYSlider.getValue() });
+                textInnerShadow.setOffset ({ offsetXSlider.getValue(), offsetYSlider.getValue() });
                 repaint();
             };
 

--- a/melatonin/cached_blur.cpp
+++ b/melatonin/cached_blur.cpp
@@ -40,12 +40,10 @@ namespace melatonin
         needsRedraw = true;
     }
 
-
     juce::Image& CachedBlur::render()
     {
         // You either need to have called update or rendered with a src!
         jassert (dst.isValid());
         return dst;
     }
-
 }

--- a/melatonin/cached_blur.h
+++ b/melatonin/cached_blur.h
@@ -18,6 +18,7 @@ namespace melatonin
         juce::Image& render();
 
         void setRadius (size_t newRadius);
+        void setRadius (const float newRadius) { setRadius ((size_t) juce::roundToInt (newRadius)); }
 
     private:
         // juce::Images are value objects, reference counted behind the scenes

--- a/melatonin/internal/cached_shadows.cpp
+++ b/melatonin/internal/cached_shadows.cpp
@@ -137,10 +137,10 @@ namespace melatonin::internal
         return *this;
     }
 
-    CachedShadows& CachedShadows::setOffset (const juce::Point<double> offset, const size_t index)
+    CachedShadows& CachedShadows::setOffset (const juce::Point<int> offset, const size_t index)
     {
         if (canUpdateShadow (index))
-            needsRecomposite |= renderedSingleChannelShadows[index].updateOffset (offset.roundToInt(), scale);
+            needsRecomposite |= renderedSingleChannelShadows[index].updateOffset (offset, scale);
 
         return *this;
     }

--- a/melatonin/internal/cached_shadows.cpp
+++ b/melatonin/internal/cached_shadows.cpp
@@ -34,7 +34,7 @@ namespace melatonin::internal
         }
     }
 
-    CachedShadows::CachedShadows (const std::initializer_list<float> radii, const bool isInner)
+    CachedShadows::CachedShadows (const std::initializer_list<double> radii, const bool isInner)
     {
         for (const auto radius : radii)
         {
@@ -121,7 +121,7 @@ namespace melatonin::internal
         render (g, text, juce::Rectangle<int> (x, y, width, height).toFloat(), justification);
     }
 
-    CachedShadows& CachedShadows::setRadius (const float radius, const size_t index)
+    CachedShadows& CachedShadows::setRadius (const double radius, const size_t index)
     {
         if (canUpdateShadow (index))
             needsRecalculate |= renderedSingleChannelShadows[index].updateRadius ((int) radius);
@@ -129,7 +129,7 @@ namespace melatonin::internal
         return *this;
     }
 
-    CachedShadows& CachedShadows::setSpread (const float spread, const size_t index)
+    CachedShadows& CachedShadows::setSpread (const double spread, const size_t index)
     {
         if (canUpdateShadow (index))
             needsRecalculate |= renderedSingleChannelShadows[index].updateSpread ((int) spread);
@@ -153,10 +153,10 @@ namespace melatonin::internal
         return *this;
     }
 
-    CachedShadows& CachedShadows::setOpacity (float opacity, size_t index)
+    CachedShadows& CachedShadows::setOpacity (double opacity, size_t index)
     {
         if (canUpdateShadow (index))
-            needsRecomposite |= renderedSingleChannelShadows[index].updateOpacity (opacity);
+            needsRecomposite |= renderedSingleChannelShadows[index].updateOpacity (static_cast<float> (opacity));
 
         return *this;
     }

--- a/melatonin/internal/cached_shadows.h
+++ b/melatonin/internal/cached_shadows.h
@@ -16,7 +16,7 @@ namespace melatonin::internal
 
         // allow us to just pass multiple radii to get multiple shadows
         CachedShadows (std::initializer_list<int> radii, bool isInner = false);
-        CachedShadows (std::initializer_list<float> radii, bool isInner = false);
+        CachedShadows (std::initializer_list<double> radii, bool isInner = false);
 
         // multiple shadows
         CachedShadows (std::initializer_list<ShadowParametersInt> shadowParameters, bool force_inner = false);
@@ -38,14 +38,13 @@ namespace melatonin::internal
         void render (juce::Graphics& g, const juce::String& text, int x, int y, int width, int height, juce::Justification justification);
 
         // these are float that will round, ints will implicitly convert
-        CachedShadows& setRadius (float radius, size_t index = 0);
-        CachedShadows& setSpread (float spread, size_t index = 0);
+        CachedShadows& setRadius (double radius, size_t index = 0);
+        CachedShadows& setSpread (double spread, size_t index = 0);
 
         // this takes a double so that it's happy implicitly converting to float and then eventually int
         CachedShadows& setOffset (juce::Point<double> offset, size_t index = 0);
         CachedShadows& setColor (juce::Colour color, size_t index = 0);
-        CachedShadows& setOpacity (float opacity, size_t index = 0);
-
+        CachedShadows& setOpacity (double opacity, size_t index = 0);
 
         // helps with testing and debugging cache
         [[nodiscard]] bool willRecalculate() const { return needsRecalculate; }
@@ -58,6 +57,18 @@ namespace melatonin::internal
         virtual ShadowParametersInt emptyShadow()
         {
             return ShadowParametersInt {};
+        }
+
+        template <typename T>
+        static std::vector<ShadowParametersInt> convertToIntParameters (std::initializer_list<ShadowParameters<T>> params)
+        {
+            std::vector<ShadowParametersInt> intParams;
+            intParams.reserve (params.size());
+            for (const auto& p : params)
+            {
+                intParams.push_back (ShadowParametersInt (p));
+            }
+            return intParams;
         }
 
     private:

--- a/melatonin/internal/cached_shadows.h
+++ b/melatonin/internal/cached_shadows.h
@@ -9,18 +9,22 @@ namespace melatonin::internal
     {
     protected:
         CachedShadows() = default;
-        CachedShadows (const CachedShadows&) = default;
+        CachedShadows (const CachedShadows&) = delete;
         CachedShadows& operator= (const CachedShadows&) = default;
-        CachedShadows (CachedShadows&&) = default;
+        CachedShadows (CachedShadows&&) = delete;
         CachedShadows& operator= (CachedShadows&&) = default;
-        
-        CachedShadows (std::initializer_list<ShadowParameters> shadowParameters, bool force_inner = false);
-        explicit CachedShadows (const std::vector<ShadowParameters>& shadowParameters, bool force_inner = false);
-        
-        virtual ~CachedShadows() = default;
-        
-    public:
 
+        // allow us to just pass multiple radii to get multiple shadows
+        CachedShadows (std::initializer_list<int> radii, bool isInner = false);
+        CachedShadows (std::initializer_list<float> radii, bool isInner = false);
+
+        // multiple shadows
+        CachedShadows (std::initializer_list<ShadowParametersInt> shadowParameters, bool force_inner = false);
+        explicit CachedShadows (const std::vector<ShadowParametersInt>& shadowParameters, bool force_inner = false);
+
+        virtual ~CachedShadows() = default;
+
+    public:
         // store a copy of the path to compare against for caching
         // public for testability, sorry not sorry
         // too lazy to break out ARGBComposite into its own class
@@ -33,19 +37,27 @@ namespace melatonin::internal
         void render (juce::Graphics& g, const juce::String& text, const juce::Rectangle<int>& area, juce::Justification justification);
         void render (juce::Graphics& g, const juce::String& text, int x, int y, int width, int height, juce::Justification justification);
 
-        CachedShadows& setRadius (size_t radius, size_t index = 0);
-        CachedShadows& setSpread (size_t spread, size_t index = 0);
-        CachedShadows& setOffset (juce::Point<int> offset, size_t index = 0);
+        // these are float that will round, ints will implicitly convert
+        CachedShadows& setRadius (float radius, size_t index = 0);
+        CachedShadows& setSpread (float spread, size_t index = 0);
+
+        // this takes a double so that it's happy implicitly converting to float and then eventually int
+        CachedShadows& setOffset (juce::Point<double> offset, size_t index = 0);
         CachedShadows& setColor (juce::Colour color, size_t index = 0);
         CachedShadows& setOpacity (float opacity, size_t index = 0);
+
+
+        // helps with testing and debugging cache
+        [[nodiscard]] bool willRecalculate() const { return needsRecalculate; }
+        [[nodiscard]] bool willRecomposite() const { return needsRecomposite; }
 
     protected:
         // TODO: Is there a better pattern here?
         // InnerShadow must set inner=true
-        // Maybe "inner" is better as a member of CachedShadows vs. ShadowParameters?
-        virtual ShadowParameters emptyShadow()
+        // Maybe "inner" is better as a member of CachedShadows vs. ShadowParametersInt?
+        virtual ShadowParametersInt emptyShadow()
         {
-            return ShadowParameters {};
+            return ShadowParametersInt {};
         }
 
     private:
@@ -56,12 +68,14 @@ namespace melatonin::internal
         juce::Image compositedARGB;
         juce::Point<float> scaledCompositePosition;
 
-        // each component blur is stored here, their positions are stored in ShadowParameters
+        // each component blur is stored here, their positions are stored in ShadowParametersInt
         std::vector<RenderedSingleChannelShadow> renderedSingleChannelShadows;
+
+        // if radius/spread stay the same, we can reuse the blur
+        bool needsRecalculate = true;
 
         // this lets us adjust color/opacity without re-rendering blurs
         bool needsRecomposite = true;
-        bool needsRecalculate = true;
 
         float scale = 1.0;
 
@@ -71,11 +85,11 @@ namespace melatonin::internal
         struct TextArrangement
         {
             juce::String text;
-            #if JUCE_MAJOR_VERSION >= 8
+#if JUCE_MAJOR_VERSION >= 8
             juce::Font font = juce::FontOptions {};
-            #else
+#else
             juce::Font font;
-            #endif
+#endif
             juce::Rectangle<float> area;
             juce::Justification justification = juce::Justification::left;
 

--- a/melatonin/internal/rendered_single_channel_shadow.cpp
+++ b/melatonin/internal/rendered_single_channel_shadow.cpp
@@ -4,7 +4,7 @@
 
 namespace melatonin::internal
 {
-    RenderedSingleChannelShadow::RenderedSingleChannelShadow (ShadowParameters p) : parameters (p) {}
+    RenderedSingleChannelShadow::RenderedSingleChannelShadow (ShadowParametersInt p) : parameters (p) {}
 
     juce::Image& RenderedSingleChannelShadow::render (juce::Path& originAgnosticPath, float scale, bool stroked)
     {

--- a/melatonin/internal/rendered_single_channel_shadow.h
+++ b/melatonin/internal/rendered_single_channel_shadow.h
@@ -6,6 +6,7 @@ namespace melatonin
     // these are the parameters required to represent a single drop or inner shadow
     // wish I could put these in shadows.h to help people
     template <typename ValueType = int>
+
     struct ShadowParameters
     {
         // one single color per shadow
@@ -22,21 +23,30 @@ namespace melatonin
 
         // Needed for aggregate-style initialization
         ShadowParameters (juce::Colour c, ValueType r, juce::Point<ValueType> o = {}, ValueType s = 0, bool i = false)
-            : color (c), radius (r), offset (o), spread (s), inner(i) {}
+            : color (c), radius (r), offset (o), spread (s), inner (i) {}
 
         // round all non-int types
         template <typename OtherType>
         explicit ShadowParameters (const ShadowParameters<OtherType>& other)
             : color (other.color),
               radius (juce::roundToInt (other.radius)),
-              offset (other.roundToInt()),
+              offset (other.offset.toInt()),
               spread (juce::roundToInt (other.spread)),
               inner (other.inner)
+        {}
+
+        // SFINAE needed to force when used in initializer lists to convert double/float to int
+        // Replace with requires when moving to C++20
+        template <typename FloatType,
+            typename = std::enable_if_t<std::is_floating_point_v<FloatType> && std::is_same_v<ValueType, int>>>
+        ShadowParameters (juce::Colour c, FloatType r, juce::Point<FloatType> o, FloatType s, bool i = false)
+            : ShadowParameters (ShadowParameters<FloatType> (c, r, o, s, i))
         {}
 
         ShadowParameters() = default;
     };
 
+    // Then your alias
     using ShadowParametersInt = ShadowParameters<>;
 
     namespace internal

--- a/melatonin/internal/rendered_single_channel_shadow.h
+++ b/melatonin/internal/rendered_single_channel_shadow.h
@@ -5,20 +5,39 @@ namespace melatonin
 {
     // these are the parameters required to represent a single drop or inner shadow
     // wish I could put these in shadows.h to help people
+    template <typename ValueType = int>
     struct ShadowParameters
     {
         // one single color per shadow
         juce::Colour color = juce::Colours::black;
-        int radius = 1;
-        juce::Point<int> offset = { 0, 0 };
+        ValueType radius = 1;
+        juce::Point<ValueType> offset = { 0, 0 };
 
         // Spread literally just expands or contracts the *path* size
         // Inverted for inner shadows
-        int spread = 0;
+        ValueType spread = 0;
 
         // an inner shadow is just a modified drop shadow
         bool inner = false;
+
+        // Needed for aggregate-style initialization
+        ShadowParameters (juce::Colour c, ValueType r, juce::Point<ValueType> o = {}, ValueType s = 0, bool i = false)
+            : color (c), radius (r), offset (o), spread (s), inner(i) {}
+
+        // round all non-int types
+        template <typename OtherType>
+        explicit ShadowParameters (const ShadowParameters<OtherType>& other)
+            : color (other.color),
+              radius (juce::roundToInt (other.radius)),
+              offset (other.roundToInt()),
+              spread (juce::roundToInt (other.spread)),
+              inner (other.inner)
+        {}
+
+        ShadowParameters() = default;
     };
+
+    using ShadowParametersInt = ShadowParameters<>;
 
     namespace internal
     {
@@ -28,9 +47,9 @@ namespace melatonin
         class RenderedSingleChannelShadow
         {
         public:
-            ShadowParameters parameters;
+            ShadowParametersInt parameters;
 
-            explicit RenderedSingleChannelShadow (ShadowParameters p);
+            explicit RenderedSingleChannelShadow (ShadowParametersInt p);
 
             juce::Image& render (juce::Path& originAgnosticPath, float scale, bool stroked = false);
 

--- a/melatonin/shadows.h
+++ b/melatonin/shadows.h
@@ -11,9 +11,9 @@ namespace melatonin
 
         melatonin::DropShadow shadow = {{ juce::Colours::black, 8, { -2, 0 }, 2 }};
 
-        ShadowParameters is a struct that looks like this:
+        ShadowParametersInt is a struct that looks like this:
 
-        struct ShadowParameters
+        struct ShadowParametersInt
         {
             // one single color per shadow
             juce::Colour color = {};
@@ -33,19 +33,35 @@ namespace melatonin
     public:
         DropShadow() = default;
 
+        // allow us to just pass a radius to get a black shadow
+        explicit DropShadow (const int radius) : CachedShadows ({ { juce::Colours::black, radius } }) {}
+        explicit DropShadow (const float radius) : CachedShadows ({ { juce::Colours::black, juce::roundToInt (radius) } }) {}
+
+        // allow us to just pass multiple radii to get multiple shadows
+        DropShadow (std::initializer_list<int> radii) : CachedShadows (radii) {}
+
         // individual arguments
-        DropShadow (juce::Colour color, int radius, juce::Point<int> offset = { 0, 0 }, int spread = 0)
+        DropShadow (const juce::Colour color, const int radius, const juce::Point<int> offset = { 0, 0 }, const int spread = 0)
             : CachedShadows ({ { color, radius, offset, spread } }) {}
 
-        // single ShadowParameters
-        // melatonin::DropShadow ({Colour::fromRGBA (255, 183, 43, 111), pulse (6)}).render (g, button);
-        explicit DropShadow (ShadowParameters p) : CachedShadows ({ p }) {}
+        // randall-style float arguments (these get rounded)
+        DropShadow (const juce::Colour color, const float radius, const juce::Point<float> offset = { 0, 0 }, const float spread = 0)
+            : CachedShadows ({ { color, juce::roundToInt (radius), { juce::roundToInt (offset.x), juce::roundToInt (offset.y) }, juce::roundToInt (spread) } }) {}
 
-        // multiple ShadowParameters
-        DropShadow (std::initializer_list<ShadowParameters> p) : CachedShadows (p) {}
+        // single ShadowParameters with integer arguments
+        // melatonin::DropShadow ({Colour::fromRGBA (255, 183, 43, 111), pulse (6)}).render (g, button);
+        explicit DropShadow (ShadowParametersInt p) : CachedShadows ({ p }) {}
+
+        // single ShadowParameters with float/double argumuents
+        template <typename T>
+        explicit DropShadow (const ShadowParameters<T>& p) : CachedShadows ({ p })
+        {}
+
+        // multiple ShadowParametersInt
+        DropShadow (std::initializer_list<ShadowParametersInt> p) : CachedShadows (p) {}
 
         // multiple via a std::vector
-        DropShadow (const std::vector<ShadowParameters>& p) : CachedShadows (p) {}
+        DropShadow (const std::vector<ShadowParametersInt>& p) : CachedShadows (p) {}
     };
 
     // An inner shadow is basically the *inverted* filled path, blurred and clipped to the path
@@ -55,23 +71,34 @@ namespace melatonin
     public:
         InnerShadow() = default;
 
+        // allow us to just pass a radius to get a black shadow
+        explicit InnerShadow (const int radius) : CachedShadows ({ { juce::Colours::black, radius } }, true) {}
+        explicit InnerShadow (const float radius) : CachedShadows ({ { juce::Colours::black, juce::roundToInt (radius) } }, true) {}
+
+        // allow us to just pass multiple radii to get multiple shadows
+        InnerShadow (std::initializer_list<int> radii) : CachedShadows (radii, true) {}
+
         // individual arguments
-        InnerShadow (juce::Colour color, int radius, juce::Point<int> offset = { 0, 0 }, int spread = 0)
+        InnerShadow (const juce::Colour color, const int radius, const juce::Point<int> offset = { 0, 0 }, const int spread = 0)
             : CachedShadows ({ { color, radius, offset, spread } }, true) {}
 
+        // randall-style float arguments
+        InnerShadow (const juce::Colour color, const float radius, const juce::Point<float> offset = { 0, 0 }, const float spread = 0)
+            : CachedShadows ({ { color, juce::roundToInt (radius), { juce::roundToInt (offset.x), juce::roundToInt (offset.y) }, juce::roundToInt (spread) } }, true) {}
+
         // single
-        explicit InnerShadow (ShadowParameters p) : CachedShadows ({ p }, true) {}
+        explicit InnerShadow (ShadowParametersInt p) : CachedShadows ({ p }, true) {}
 
         // multiple shadows
-        InnerShadow (std::initializer_list<ShadowParameters> p) : CachedShadows (p, true) {}
+        InnerShadow (std::initializer_list<ShadowParametersInt> p) : CachedShadows (p, true) {}
 
         // multiple via a std::vector
-        InnerShadow (const std::vector<ShadowParameters>& p) : CachedShadows (p, true) {}
+        explicit InnerShadow (const std::vector<ShadowParametersInt>& p) : CachedShadows (p, true) {}
 
     private:
-        ShadowParameters emptyShadow() override
+        ShadowParametersInt emptyShadow() override
         {
-            auto empty = ShadowParameters {};
+            auto empty = ShadowParametersInt {};
             empty.inner = true;
             return empty;
         }
@@ -87,10 +114,10 @@ namespace melatonin
         PathWithShadows() = default;
 
         // multiple shadows
-        PathWithShadows (std::initializer_list<ShadowParameters> p)
+        PathWithShadows (std::initializer_list<ShadowParametersInt> p)
         {
-            std::vector<ShadowParameters> innerParameters;
-            std::vector<ShadowParameters> dropParameters;
+            std::vector<ShadowParametersInt> innerParameters;
+            std::vector<ShadowParametersInt> dropParameters;
             for (const auto& param : p)
             {
                 if (param.inner)

--- a/melatonin/shadows.h
+++ b/melatonin/shadows.h
@@ -33,12 +33,11 @@ namespace melatonin
     public:
         DropShadow() = default;
 
-        // allow us to just pass a radius to get a black shadow
-        explicit DropShadow (const int radius) : CachedShadows ({ { juce::Colours::black, radius } }) {}
-        explicit DropShadow (const float radius) : CachedShadows ({ { juce::Colours::black, juce::roundToInt (radius) } }) {}
+        // allow us to just pass a double/float/int (implicitly converted) radius to get a black shadow
+        explicit DropShadow (const double radius) : CachedShadows ({ { juce::Colours::black, juce::roundToInt (radius) } }) {}
 
         // allow us to just pass multiple radii to get multiple shadows
-        DropShadow (std::initializer_list<int> radii) : CachedShadows (radii) {}
+        DropShadow (std::initializer_list<double> radii) : CachedShadows (radii) {}
 
         // individual arguments
         DropShadow (const juce::Colour color, const int radius, const juce::Point<int> offset = { 0, 0 }, const int spread = 0)
@@ -51,11 +50,6 @@ namespace melatonin
         // single ShadowParameters with integer arguments
         // melatonin::DropShadow ({Colour::fromRGBA (255, 183, 43, 111), pulse (6)}).render (g, button);
         explicit DropShadow (ShadowParametersInt p) : CachedShadows ({ p }) {}
-
-        // single ShadowParameters with float/double argumuents
-        template <typename T>
-        explicit DropShadow (const ShadowParameters<T>& p) : CachedShadows ({ p })
-        {}
 
         // multiple ShadowParametersInt
         DropShadow (std::initializer_list<ShadowParametersInt> p) : CachedShadows (p) {}
@@ -72,11 +66,10 @@ namespace melatonin
         InnerShadow() = default;
 
         // allow us to just pass a radius to get a black shadow
-        explicit InnerShadow (const int radius) : CachedShadows ({ { juce::Colours::black, radius } }, true) {}
-        explicit InnerShadow (const float radius) : CachedShadows ({ { juce::Colours::black, juce::roundToInt (radius) } }, true) {}
+        explicit InnerShadow (const double radius) : CachedShadows ({ { juce::Colours::black, juce::roundToInt (radius) } }, true) {}
 
         // allow us to just pass multiple radii to get multiple shadows
-        InnerShadow (std::initializer_list<int> radii) : CachedShadows (radii, true) {}
+        InnerShadow (std::initializer_list<double> radii) : CachedShadows (radii, true) {}
 
         // individual arguments
         InnerShadow (const juce::Colour color, const int radius, const juce::Point<int> offset = { 0, 0 }, const int spread = 0)

--- a/melatonin_blur.h
+++ b/melatonin_blur.h
@@ -5,7 +5,7 @@ BEGIN_JUCE_MODULE_DECLARATION
 
 ID:               melatonin_blur
 vendor:           Sudara
-version:          1.3.0
+version:          1.4.0
 name:             Optimized CPU vector blurring and JUCE drop shadowing with tests and benchmarks
 description:      Blurry Life
 license:          MIT

--- a/tests/composite_argb.cpp
+++ b/tests/composite_argb.cpp
@@ -18,7 +18,7 @@ TEST_CASE ("Melatonin Blur Composite ARGB")
 
         SECTION ("match a single channel blur")
         {
-            auto s1 = melatonin::ShadowParameters ({ juce::Colours::black, 2, { 0, 0 }, 0 });
+            auto s1 = melatonin::ShadowParametersInt ({ juce::Colours::black, 2, { 0, 0 }, 0 });
 
             juce::Path p;
             // make a 4x4 at 2,2
@@ -37,7 +37,7 @@ TEST_CASE ("Melatonin Blur Composite ARGB")
 
         SECTION ("applies offset correctly")
         {
-            auto s1 = melatonin::ShadowParameters ({ juce::Colours::black, 2, { 2, 2 }, 0 });
+            auto s1 = melatonin::ShadowParametersInt ({ juce::Colours::black, 2, { 2, 2 }, 0 });
 
             juce::Path p;
             // make a 4x4 at 2,2
@@ -58,10 +58,10 @@ TEST_CASE ("Melatonin Blur Composite ARGB")
 
         SECTION ("takes the larger of 2 blur bounds")
         {
-            auto s1 = melatonin::ShadowParameters ({ juce::Colours::black, 2, { 0, 0 }, 0 });
+            auto s1 = melatonin::ShadowParametersInt ({ juce::Colours::black, 2, { 0, 0 }, 0 });
 
             // this has a 2px positive offset on the x axis
-            auto s2 = melatonin::ShadowParameters ({ juce::Colours::black, 3, { 0, 0 }, 0 });
+            auto s2 = melatonin::ShadowParametersInt ({ juce::Colours::black, 3, { 0, 0 }, 0 });
 
             juce::Path p;
             // make a 4x4 at 2,2
@@ -80,10 +80,10 @@ TEST_CASE ("Melatonin Blur Composite ARGB")
 
         SECTION ("takes offset into account when unioning bounds")
         {
-            auto s1 = melatonin::ShadowParameters ({ juce::Colours::black, 2, { 0, 0 }, 0 });
+            auto s1 = melatonin::ShadowParametersInt ({ juce::Colours::black, 2, { 0, 0 }, 0 });
 
             // this has a 2px positive offset on the x axis
-            auto s2 = melatonin::ShadowParameters ({ juce::Colours::black, 2, { 2, 0 }, 0 });
+            auto s2 = melatonin::ShadowParametersInt ({ juce::Colours::black, 2, { 2, 0 }, 0 });
 
             juce::Path p;
             // make a 4x4 at 2,2
@@ -103,7 +103,7 @@ TEST_CASE ("Melatonin Blur Composite ARGB")
 
         SECTION ("doesn't freak out with 0 radius")
         {
-            auto s1 = melatonin::ShadowParameters ({ juce::Colours::black, 0, { 0, 0 }, 0 });
+            auto s1 = melatonin::ShadowParametersInt ({ juce::Colours::black, 0, { 0, 0 }, 0 });
 
             juce::Path p;
             // make a 4x4 at 2,2
@@ -131,7 +131,7 @@ TEST_CASE ("Melatonin Blur Composite ARGB")
         g.addTransform (juce::AffineTransform::scale (2));
         g.fillAll (juce::Colours::white);
 
-        auto dummyShadow = melatonin::ShadowParameters ({ juce::Colours::black, 2, { 0, 0 }, 0 });
+        auto dummyShadow = melatonin::ShadowParametersInt ({ juce::Colours::black, 2, { 0, 0 }, 0 });
 
         juce::Path p;
         p.addRectangle (juce::Rectangle<float> (0, 0, 4, 4));

--- a/tests/constructors_and_float_parameters.cpp
+++ b/tests/constructors_and_float_parameters.cpp
@@ -1,0 +1,191 @@
+#include "../melatonin/internal/implementations.h"
+#include "../melatonin/shadows.h"
+#include "helpers/pixel_helpers.h"
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
+
+static void render (melatonin::DropShadow& shadow, juce::Image& result, juce::Path& p)
+{
+    juce::Graphics g (result);
+    g.fillAll (juce::Colours::white);
+    shadow.render (g, p);
+}
+
+TEST_CASE ("Melatonin Blur Constructors and Float Parameters")
+{
+    // here's what our test image looks like:
+    // 0=white, 1=black, just to be annoying...
+
+    // 0  0  0  0  0  0  0  0  0
+    // 0  0  0  0  0  0  0  0  0
+    // 0  0  0  0  0  0  0  0  0
+    // 0  0  0  1  1  1  0  0  0
+    // 0  0  0  1  1  1  0  0  0
+    // 0  0  0  1  1  1  0  0  0
+    // 0  0  0  0  0  0  0  0  0
+    // 0  0  0  0  0  0  0  0  0
+    // 0  0  0  0  0  0  0  0  0
+
+    // create a 3px by 3px square
+    auto bounds = juce::Rectangle<float> (3, 3);
+    juce::Path p;
+
+    // stick the 3x3 box centered inside a 9x9
+    p.addRectangle (bounds.translated (3, 3));
+
+    // needed for JUCE not to pee its pants (aka leak) when working with graphics
+    juce::ScopedJuceInitialiser_GUI juce;
+
+    juce::Image result (juce::Image::ARGB, 9, 9, true);
+
+    SECTION ("constructors")
+    {
+        SECTION ("takes just a radius via direct init")
+        {
+            melatonin::DropShadow shadow { 2 };
+            render (shadow, result, p);
+            CHECK (filledBounds (result).toString() == juce::Rectangle<int> (1, 1, 7, 7).toString());
+        }
+
+        SECTION ("takes multiple radii to setup multiple black shadows")
+        {
+            melatonin::DropShadow shadows { 1, 2 };
+            render (shadows, result, p);
+            CHECK (filledBounds (result).toString() == juce::Rectangle<int> (1, 1, 7, 7).toString());
+        }
+
+        SECTION ("takes just raw color and radius via direct init")
+        {
+            melatonin::DropShadow shadow { juce::Colours::black, 1 };
+            render (shadow, result, p);
+            CHECK (filledBounds (result).toString() == juce::Rectangle<int> (2, 2, 5, 5).toString());
+        }
+
+        SECTION ("takes just raw color and radius via copy init")
+        {
+            melatonin::DropShadow shadow = { juce::Colours::black, 1 };
+            render (shadow, result, p);
+            CHECK (filledBounds (result).toString() == juce::Rectangle<int> (2, 2, 5, 5).toString());
+        }
+
+        SECTION ("takes raw color and radius and offset")
+        {
+            melatonin::DropShadow shadow = { juce::Colours::black, 1, { 1, 1 } };
+            render (shadow, result, p);
+            CHECK (filledBounds (result).toString() == juce::Rectangle<int> (3, 3, 5, 5).toString());
+        }
+
+        SECTION ("takes a ShadowParameters object via direct and copy init")
+        {
+            melatonin::DropShadow shadow { { juce::Colours::black, 1, { 1, 1 }, 0 } };
+            render (shadow, result, p);
+            shadow = { { juce::Colours::black, 1, { 1, 1 }, 0 } };
+            render (shadow, result, p);
+            CHECK (filledBounds (result).toString() == juce::Rectangle<int> (3, 3, 5, 5).toString());
+        }
+
+        SECTION ("takes multiple ShadowParameters objects via direct and copy init")
+        {
+            melatonin::DropShadow shadow { { juce::Colours::black, 1, { 1, 1 }, 0 }, { juce::Colours::black, 1, { 1, 1 }, 0 } };
+            shadow = { { juce::Colours::black, 1, { 1, 1 }, 0 }, { juce::Colours::black, 1, { 1, 1 }, 0 } };
+            render (shadow, result, p);
+        }
+    }
+
+    SECTION ("float constructors")
+    {
+        SECTION ("float radius")
+        {
+            SECTION ("rounds down")
+            {
+                melatonin::DropShadow shadow = { juce::Colours::black, 1.4f };
+                render (shadow, result, p);
+                CHECK (filledBounds (result).toString() == juce::Rectangle<int> (2, 2, 5, 5).toString());
+            }
+
+            SECTION ("rounds up")
+            {
+                melatonin::DropShadow shadow = { juce::Colours::black, 1.6f };
+                render (shadow, result, p);
+                CHECK (filledBounds (result).toString() == juce::Rectangle<int> (1, 1, 7, 7).toString());
+            }
+        }
+
+        SECTION ("float spread")
+        {
+            SECTION ("rounds down")
+            {
+                melatonin::DropShadow shadow = { juce::Colours::black, 1.0, { 0, 0 }, 0.4f };
+                render (shadow, result, p);
+                CHECK (filledBounds (result).toString() == juce::Rectangle<int> (2, 2, 5, 5).toString());
+            }
+
+            SECTION ("rounds up")
+            {
+                melatonin::DropShadow shadow = { juce::Colours::black, 1.0, { 0, 0 }, 0.6f };
+                render (shadow, result, p);
+                CHECK (filledBounds (result).toString() == juce::Rectangle<int> (1, 1, 7, 7).toString());
+            }
+        }
+
+        SECTION ("float offset")
+        {
+            SECTION ("rounds down")
+            {
+                melatonin::DropShadow shadow = { juce::Colours::black, 1.0f, { 1.4f, 1.4f } };
+                render (shadow, result, p);
+                CHECK (filledBounds (result).toString() == juce::Rectangle<int> (3, 3, 5, 5).toString());
+            }
+
+            SECTION ("rounds up")
+            {
+                melatonin::DropShadow shadow = { juce::Colours::black, 1.0f, { 1.6f, 1.6f } };
+                render (shadow, result, p);
+                CHECK (filledBounds (result).toString() == juce::Rectangle<int> (4, 4, 5, 5).toString());
+            }
+        }
+    }
+
+    SECTION ("float setters")
+    {
+        melatonin::DropShadow shadow;
+        juce::Image floatResult (juce::Image::ARGB, 9, 9, true);
+
+        SECTION ("radius")
+        {
+            shadow.setRadius (1);
+            render (shadow, result, p);
+
+            shadow.setRadius (1.4f);
+            CHECK (shadow.willRecalculate() == false);
+            render (shadow, floatResult, p);
+
+            CHECK (imagesAreIdentical (result, floatResult));
+        }
+
+        SECTION ("spread")
+        {
+            shadow.setSpread (1);
+            render (shadow, result, p);
+
+            shadow.setSpread (1.4f);
+            CHECK (shadow.willRecalculate() == false);
+            render (shadow, floatResult, p);
+
+            CHECK (imagesAreIdentical (result, floatResult));
+        }
+
+        SECTION ("offset")
+        {
+            shadow.setOffset ({ 1, 1 });
+            render (shadow, result, p);
+
+            shadow.setOffset ({ 1.4f, 1.4f });
+            CHECK (shadow.willRecomposite() == false);
+            render (shadow, floatResult, p);
+
+            CHECK (imagesAreIdentical (result, floatResult));
+        }
+    }
+}

--- a/tests/constructors_and_float_parameters.cpp
+++ b/tests/constructors_and_float_parameters.cpp
@@ -93,8 +93,43 @@ TEST_CASE ("Melatonin Blur Constructors and Float Parameters")
         }
     }
 
-    SECTION ("float constructors")
+    SECTION ("float")
     {
+        SECTION ("constructors")
+        {
+            SECTION ("takes just a radius via direct init")
+            {
+                melatonin::DropShadow shadow { 2.2 };
+                shadow = { 2.2f };
+                render (shadow, result, p);
+                CHECK (filledBounds (result).toString() == juce::Rectangle<int> (1, 1, 7, 7).toString());
+            }
+
+            SECTION ("takes multiple radii to setup multiple black shadows")
+            {
+                melatonin::DropShadow shadows { 1.2f, 2.5f };
+                shadows = { 1.2, 2.5 };
+                render (shadows, result, p);
+                CHECK (filledBounds (result).toString() == juce::Rectangle<int> (1, 1, 7, 7).toString());
+            }
+
+            SECTION ("takes a ShadowParameters object via direct and copy init")
+            {
+                melatonin::DropShadow shadow { { juce::Colours::black, 1.2f, { 1.1f, 1.1f }, 0.1f } };
+                render (shadow, result, p);
+                shadow = { { juce::Colours::black, 1, { 1, 1 }, 0 } };
+                render (shadow, result, p);
+                CHECK (filledBounds (result).toString() == juce::Rectangle<int> (3, 3, 5, 5).toString());
+            }
+
+            SECTION ("takes multiple ShadowParameters objects via direct and copy init")
+            {
+                melatonin::DropShadow shadow { { juce::Colours::black, 1.2f, { 1.1f, 1.1f }, 0.f }, { juce::Colours::black, 1.f, { 1.f, 1.f }, 0.f } };
+                shadow = { { juce::Colours::black, 1.f, { 1.f, 1.f }, 0.f }, { juce::Colours::black, 1.f, { 1.f, 1.f }, 0.f } };
+                render (shadow, result, p);
+            }
+        }
+
         SECTION ("float radius")
         {
             SECTION ("rounds down")

--- a/tests/constructors_and_float_parameters.cpp
+++ b/tests/constructors_and_float_parameters.cpp
@@ -216,7 +216,7 @@ TEST_CASE ("Melatonin Blur Constructors and Float Parameters")
             shadow.setOffset ({ 1, 1 });
             render (shadow, result, p);
 
-            shadow.setOffset ({ 1.4f, 1.4f });
+            shadow.setOffset ( { 1.4f, 1.4f });
             CHECK (shadow.willRecomposite() == false);
             render (shadow, floatResult, p);
 

--- a/tests/drop_shadow.cpp
+++ b/tests/drop_shadow.cpp
@@ -27,9 +27,6 @@ TEST_CASE ("Melatonin Blur Drop Shadow")
     // stick the 3x3 box centered inside a 9x9
     p.addRectangle (bounds.translated (3, 3));
 
-    // needed for JUCE not to pee its pants (aka leak) when working with graphics
-    juce::ScopedJuceInitialiser_GUI juce;
-
     juce::Image result (juce::Image::ARGB, 9, 9, true);
 
     SECTION ("no shadow")

--- a/tests/render_single_channel.cpp
+++ b/tests/render_single_channel.cpp
@@ -9,7 +9,7 @@
 TEST_CASE ("Melatonin Blur Render To Single Channel")
 {
     using namespace melatonin::internal;
-    auto dummyShadow = melatonin::ShadowParameters ({ juce::Colours::black, 2, { 0, 0 }, 0 });
+    auto dummyShadow = melatonin::ShadowParametersInt ({ juce::Colours::black, 2, { 0, 0 }, 0 });
 
     juce::Path p;
     p.addRectangle (juce::Rectangle<float> (4, 4));
@@ -54,7 +54,7 @@ TEST_CASE ("Melatonin Blur Render To Single Channel")
     {
         auto result = RenderedSingleChannelShadow (dummyShadow).render (p, 1);
 
-        auto lowerAlpha = melatonin::ShadowParameters ({ juce::Colours::black, 2, { 0, 0 }, 0 });
+        auto lowerAlpha = melatonin::ShadowParametersInt ({ juce::Colours::black, 2, { 0, 0 }, 0 });
         auto resultWithLowerAlpha = RenderedSingleChannelShadow (lowerAlpha).render (p, 1);
 
         // check each pixel
@@ -74,7 +74,7 @@ TEST_CASE ("Melatonin Blur Render To Single Channel")
     {
         auto result = RenderedSingleChannelShadow (dummyShadow).render (p, 1);
 
-        auto offsetShadow = melatonin::ShadowParameters ({ juce::Colours::black, 2, { 2, 2 }, 0 });
+        auto offsetShadow = melatonin::ShadowParametersInt ({ juce::Colours::black, 2, { 2, 2 }, 0 });
         auto resultWithOffset = RenderedSingleChannelShadow (offsetShadow).render (p, 1);
 
         // TODO: this isn't working for some reason, even when bounds differ, these pass
@@ -138,7 +138,7 @@ TEST_CASE ("Melatonin Blur Render To Single Channel")
         {
             SECTION ("scales with radius")
             {
-                dummyShadow = melatonin::ShadowParameters ({ juce::Colours::black, 2, { 0, 0 }, 0, true });
+                dummyShadow = melatonin::ShadowParameters<> ({ juce::Colours::black, 2, { 0, 0 }, 0, true });
                 auto result = RenderedSingleChannelShadow (dummyShadow).render (p, 1);
                 CHECK (result.getWidth() == 8);
                 dummyShadow.radius = 3;

--- a/tests/setters.cpp
+++ b/tests/setters.cpp
@@ -48,13 +48,63 @@ TEST_CASE ("Melatonin Blur Setters")
             shadow.setRadius (1);
             render (shadow, result, p);
 
-            // check bounds of non-white rectangle
-            CHECK (filledBounds (result).toString() == juce::Rectangle<int> (2, 2, 5, 5).toString());
+            SECTION ("works")
+            {
+                // check bounds of non-white rectangle
+                CHECK (filledBounds (result).toString() == juce::Rectangle<int> (2, 2, 5, 5).toString());
 
-            shadow.setOffset ({ 2, 2 });
-            render (shadow, result, p);
+                shadow.setOffset ({ 2, 2 });
+                render (shadow, result, p);
 
-            CHECK (filledBounds (result).toString() == juce::Rectangle<int> (4, 4, 5, 5).toString());
+                CHECK (filledBounds (result).toString() == juce::Rectangle<int> (4, 4, 5, 5).toString());
+            }
+
+            SECTION ("takes int points")
+            {
+                auto intPoint = juce::Point<int> { 2, 2 };
+                shadow.setOffset (intPoint);
+            }
+
+            SECTION ("takes int literals in brace init")
+            {
+                shadow.setOffset ({ 2, 2 });
+            }
+
+            SECTION ("takes floating point Point")
+            {
+                juce::Point floatPoint { 2.f, 2.f };
+                shadow.setOffset (floatPoint);
+            }
+
+            SECTION ("takes float literals in brace init ")
+            {
+                shadow.setOffset ({ 2.f, 2.f });
+            }
+
+            SECTION ("takes double literals in brace init")
+            {
+                shadow.setOffset ({ 2.0, 2.0 });
+            }
+
+            SECTION ("takes Point<double>")
+            {
+                shadow.setOffset (juce::Point<double> { 2.0, 2.0 });
+            }
+
+            SECTION ("takes x,y integers")
+            {
+                shadow.setOffset (1, 2);
+            }
+
+            SECTION ("takes x,y floats")
+            {
+                shadow.setOffset (1.f, 2.f);
+            }
+
+            SECTION ("takes x,y doubles")
+            {
+                shadow.setOffset (1.0, 2.0);
+            }
         }
 
         SECTION ("setRadius")

--- a/tests/setters.cpp
+++ b/tests/setters.cpp
@@ -1,0 +1,180 @@
+#include "../melatonin/internal/implementations.h"
+#include "../melatonin/shadows.h"
+#include "helpers/pixel_helpers.h"
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
+
+static void render (melatonin::DropShadow& shadow, juce::Image& result, juce::Path& p)
+{
+    juce::Graphics g (result);
+    g.fillAll (juce::Colours::white);
+    shadow.render (g, p);
+}
+
+TEST_CASE ("Melatonin Blur Setters")
+{
+    // here's what our test image looks like:
+    // 0=white, 1=black, just to be annoying...
+
+    // 0  0  0  0  0  0  0  0  0
+    // 0  0  0  0  0  0  0  0  0
+    // 0  0  0  0  0  0  0  0  0
+    // 0  0  0  1  1  1  0  0  0
+    // 0  0  0  1  1  1  0  0  0
+    // 0  0  0  1  1  1  0  0  0
+    // 0  0  0  0  0  0  0  0  0
+    // 0  0  0  0  0  0  0  0  0
+    // 0  0  0  0  0  0  0  0  0
+
+    // create a 3px by 3px square
+    auto bounds = juce::Rectangle<float> (3, 3);
+    juce::Path p;
+
+    // stick the 3x3 box centered inside a 9x9
+    p.addRectangle (bounds.translated (3, 3));
+
+    // needed for JUCE not to pee its pants (aka leak) when working with graphics
+    juce::ScopedJuceInitialiser_GUI juce;
+
+    juce::Image result (juce::Image::ARGB, 9, 9, true);
+
+    SECTION ("Setters")
+    {
+        melatonin::DropShadow shadow;
+
+        SECTION ("setOffset")
+        {
+            shadow.setRadius (1);
+            render (shadow, result, p);
+
+            // check bounds of non-white rectangle
+            CHECK (filledBounds (result).toString() == juce::Rectangle<int> (2, 2, 5, 5).toString());
+
+            shadow.setOffset ({ 2, 2 });
+            render (shadow, result, p);
+
+            CHECK (filledBounds (result).toString() == juce::Rectangle<int> (4, 4, 5, 5).toString());
+        }
+
+        SECTION ("setRadius")
+        {
+            shadow.setRadius (2);
+            render (shadow, result, p);
+            CHECK (filledBounds (result).toString() == juce::Rectangle<int> (1, 1, 7, 7).toString());
+        }
+
+        // this just modifies the color of the shadow
+        SECTION ("setOpacity")
+        {
+            shadow.setRadius (2);
+            shadow.setOpacity (0.f);
+            render (shadow, result, p);
+            // we aren't drawing the path, so nothing is drawn
+            CHECK (filledBounds (result).toString() == juce::Rectangle<int> (0, 0, 0, 0).toString());
+        }
+
+        SECTION ("setSpread")
+        {
+            shadow.setRadius (1);
+            shadow.setSpread (1);
+            render (shadow, result, p);
+            CHECK (filledBounds (result).toString() == juce::Rectangle<int> (1, 1, 7, 7).toString());
+        }
+
+        SECTION ("setColor")
+        {
+            shadow.setRadius (1);
+            shadow.setColor (juce::Colours::red);
+            render (shadow, result, p);
+            CHECK (filledBounds (result).toString() == juce::Rectangle<int> (2, 2, 5, 5).toString());
+            save_test_image (result, "setters_color.png");
+            CHECK (getPixels (result, 4, { 4, 4 }) == "FFFF0000");
+        }
+    }
+
+    SECTION ("setters and cache")
+    {
+        melatonin::DropShadow shadow;
+        shadow.setRadius (1);
+        render (shadow, result, p);
+
+        SECTION ("radius")
+        {
+            SECTION ("keeping radius same doesn't break cache")
+            {
+                shadow.setRadius (1); // doesn't break cache
+                CHECK (shadow.willRecalculate() == false);
+                CHECK (shadow.willRecomposite() == false);
+            }
+
+            SECTION ("changing radius means recalculation")
+            {
+                shadow.setRadius (2);
+                CHECK (shadow.willRecalculate() == true);
+            }
+        }
+
+        SECTION ("offset")
+        {
+            SECTION ("keeping offset same doesn't break cache")
+            {
+                shadow.setOffset ({ 0, 0 }); // doesn't break cache
+                CHECK (shadow.willRecalculate() == false);
+                CHECK (shadow.willRecomposite() == false);
+            }
+
+            SECTION ("changing offset breaks composite cache")
+            {
+                shadow.setOffset ({ 1, 1 }); // breaks composite cache
+                CHECK (shadow.willRecalculate() == false);
+                CHECK (shadow.willRecomposite() == true);
+            }
+        }
+
+        SECTION ("color")
+        {
+            SECTION ("keeping color the same doesn't break cache")
+            {
+                shadow.setColor (juce::Colours::black);
+                CHECK (shadow.willRecalculate() == false);
+                CHECK (shadow.willRecomposite() == false);
+            }
+
+            SECTION ("changing color means recompositing")
+            {
+                shadow.setColor (juce::Colours::red);
+                CHECK (shadow.willRecalculate() == false);
+                CHECK (shadow.willRecomposite() == true);
+            }
+        }
+
+        // Regression test, this was broken during 2024
+        SECTION ("sequential setters don't confuse cache state")
+        {
+            SECTION ("setColor with new color then setOpacity with same opacity breaks cache")
+            {
+                shadow.setColor (juce::Colours::red);
+                shadow.setOpacity (1.0f);
+                CHECK (shadow.willRecalculate() == false);
+                CHECK (shadow.willRecomposite() == true);
+            }
+
+            SECTION ("setOpacity with new opacity then setColor with same color breaks cache")
+            {
+                shadow.setOpacity (0.5f);
+                shadow.setColor (juce::Colours::black.withAlpha (0.5f));
+                CHECK (shadow.willRecalculate() == false);
+                CHECK (shadow.willRecomposite() == true);
+            }
+
+            SECTION ("setRadius with new radius then setSpread with same spread still breaks cache")
+            {
+                shadow.setRadius (2);
+                shadow.setSpread (0);
+                CHECK (shadow.willRecalculate() == true);
+                CHECK (shadow.willRecomposite() == false);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the following with tests for all cases, closes #48.

It also fixes #75, a problem I ran into with setters. 

## Float constructors and attribute setters

Float/double values (randall-style), rounded to int via `juce::roundToInt`:

```cpp
// rounds down, creates black shadow with radius 1
melatonin::DropShadow shadow = { juce::Colours::black, 1.3f };

// rounds up to int radius of 2
shadow.setRadius (1.6f); 

// creates a black shadow with radius 1 and spread 1
melatonin::DropShadow shadow = { juce::Colours::black, 1.0, { 0, 0 }, 0.6f };

```


## Additional helpful constructors (with tests):

Creates a black shadow with radius of 2 with copy or direct init:

```cpp
melatonin::DropShadow shadow { 2 };
melatonin::DropShadow shadow = { 2 };
melatonin::DropShadow shadow { 2.2 };
melatonin::DropShadow shadow = { 2.2};
shadow = { 2 };
shadow = { 2.2 };
```

Creates two black shadows, one with radius 1 and one with radius 2 with either copy or direct init

```cpp
melatonin::DropShadow shadow { 1, 2 };
melatonin::DropShadow shadow { 1.1, 2.1 };
```

## Add `setOffset (x, y)`

```cpp
setOffset ({1, 1}); // init list
setOffset (1, 1); // new x,y syntax
setOffset (1.0, 1.0); // supports float and doubles
```
## Add tests for int/float setters 

As well as tests for constructors, both int and float.

Also adds `Drop/InnerShadow::willRecomposite()` and `::willRecalculate` to help make testing easier. 