### PR TITLE
Change test/benchmark guards

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.20)
 
 project(MelatoninBlur VERSION 1.0.0 LANGUAGES C CXX
-        DESCRIPTION "Fast Blurs for JUCE"
-        HOMEPAGE_URL "https://github.com/sudara/melatonin_blur")
+    DESCRIPTION "Fast Blurs for JUCE"
+    HOMEPAGE_URL "https://github.com/sudara/melatonin_blur")
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
@@ -14,26 +14,26 @@ if (MelatoninBlur_IS_TOP_LEVEL)
     if (JUCE7)
         message(STATUS "Cloning JUCE 7...")
         FetchContent_Declare(JUCE
-                GIT_REPOSITORY https://github.com/juce-framework/JUCE.git
-                GIT_TAG 7.0.12
-                GIT_PROGRESS TRUE
+            GIT_REPOSITORY https://github.com/juce-framework/JUCE.git
+            GIT_TAG 7.0.12
+            GIT_PROGRESS TRUE
         )
     else ()
         message(STATUS "Cloning JUCE 8...")
         FetchContent_Declare(JUCE
-                GIT_REPOSITORY https://github.com/juce-framework/JUCE.git
-                GIT_TAG master
-                GIT_PROGRESS TRUE
+            GIT_REPOSITORY https://github.com/juce-framework/JUCE.git
+            GIT_TAG master
+            GIT_PROGRESS TRUE
         )
     endif ()
 
     FetchContent_MakeAvailable(JUCE)
 
     FetchContent_Declare(Catch2
-            GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-            GIT_PROGRESS TRUE
-            GIT_SHALLOW TRUE
-            GIT_TAG v3.6.0)
+        GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+        GIT_PROGRESS TRUE
+        GIT_SHALLOW TRUE
+        GIT_TAG v3.7.1)
     FetchContent_MakeAvailable(Catch2) # find_package equivalent
 
     enable_testing()
@@ -53,38 +53,40 @@ if (MelatoninBlur_IS_TOP_LEVEL)
     juce_add_module("${CMAKE_CURRENT_SOURCE_DIR}")
 
     target_link_libraries(Tests PRIVATE
-            melatonin_blur
-            Catch2::Catch2WithMain
-            juce::juce_graphics # Image, etc
-            juce::juce_gui_basics # Colour, etc
-            juce::juce_audio_basics # FloatVectorOperations
-            juce::juce_recommended_config_flags
-            juce::juce_recommended_lto_flags
-            juce::juce_recommended_warning_flags)
+        melatonin_blur
+        Catch2::Catch2WithMain
+        juce::juce_graphics # Image, etc
+        juce::juce_gui_basics # Colour, etc
+        juce::juce_audio_basics # FloatVectorOperations
+        juce::juce_recommended_config_flags
+        juce::juce_recommended_lto_flags
+        juce::juce_recommended_warning_flags)
 
     target_link_libraries(Benchmarks PRIVATE
-            melatonin_blur
-            Catch2::Catch2WithMain
-            juce::juce_graphics # Image, etc
-            juce::juce_gui_basics # Colour, etc
-            juce::juce_audio_basics # FloatVectorOperations
-            juce::juce_recommended_config_flags
-            juce::juce_recommended_lto_flags
-            juce::juce_recommended_warning_flags)
+        melatonin_blur
+        Catch2::Catch2WithMain
+        juce::juce_graphics # Image, etc
+        juce::juce_gui_basics # Colour, etc
+        juce::juce_audio_basics # FloatVectorOperations
+        juce::juce_recommended_config_flags
+        juce::juce_recommended_lto_flags
+        juce::juce_recommended_warning_flags)
 
     # Enable this once tests are happy fundamentally in CI
     set_target_properties(Tests PROPERTIES COMPILE_WARNING_AS_ERROR ON)
 
     target_compile_definitions(Tests PRIVATE
-            PROJECT_ROOT="${CMAKE_SOURCE_DIR}"
-            JUCE_WEB_BROWSER=0
-            JUCE_USE_CURL=0
+        PROJECT_ROOT="${CMAKE_SOURCE_DIR}"
+        JUCE_WEB_BROWSER=0
+        JUCE_USE_CURL=0
+        RUN_MELATONIN_BLUR_TESTS=1
     )
 
     target_compile_definitions(Benchmarks PRIVATE
-            PROJECT_ROOT="${CMAKE_SOURCE_DIR}"
-            JUCE_WEB_BROWSER=0
-            JUCE_USE_CURL=0
+        PROJECT_ROOT="${CMAKE_SOURCE_DIR}"
+        JUCE_WEB_BROWSER=0
+        JUCE_USE_CURL=0
+        RUN_MELATONIN_BLUR_BENCHMARKS=1
     )
 
     include(${Catch2_SOURCE_DIR}/extras/Catch.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,8 +42,6 @@ if (MelatoninBlur_IS_TOP_LEVEL)
     target_compile_features(Tests PUBLIC cxx_std_17)
     target_compile_features(Benchmarks PUBLIC cxx_std_17)
     
-    target_sources(Benchmarks PRIVATE "benchmarks/benchmarks.cpp")
-
     # Our executables need to know about our plugin code...
     target_include_directories(Tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/source)
     target_include_directories(Benchmarks PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/source)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,9 +41,7 @@ if (MelatoninBlur_IS_TOP_LEVEL)
     add_executable(Benchmarks)
     target_compile_features(Tests PUBLIC cxx_std_17)
     target_compile_features(Benchmarks PUBLIC cxx_std_17)
-
-    file(GLOB_RECURSE BlurTests CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/tests/*.cpp")
-    target_sources(Tests PRIVATE ${BlurTests})
+    
     target_sources(Benchmarks PRIVATE "benchmarks/benchmarks.cpp")
 
     # Our executables need to know about our plugin code...

--- a/melatonin_blur.cpp
+++ b/melatonin_blur.cpp
@@ -3,11 +3,11 @@
 #include "melatonin/internal/cached_shadows.cpp"
 #include "melatonin/internal/rendered_single_channel_shadow.cpp"
 
-#if RUN_MELATONIN_BENCHMARKS
+#if RUN_MELATONIN_BLUR_BENCHMARKS
     #include "benchmarks/benchmarks.cpp"
 #endif
 
-#if RUN_MELATONIN_TESTS
+#if RUN_MELATONIN_BLUR_TESTS
     #include "tests/blur_implementations.cpp"
     #include "tests/drop_shadow.cpp"
     #include "tests/inner_shadow.cpp"


### PR DESCRIPTION
Tests and Benchmarks have been guarded by `RUN_MELATONIN_TESTS` AND `RUN_MELATONIN_BENCHMARKS`.

These guards have been made more specific now, so they are unique to this project: `RUN_MELATONIN_BLUR_TESTS` and `RUN_MELATONIN_BLUR_BENCHMARKS`

Basically, that means the tests/benchmarks will run only on this repo by default, and not as a part of my other projects.