### PR TITLE
Render stroked paths with transforms

### DIFF
--- a/melatonin/internal/cached_shadows.cpp
+++ b/melatonin/internal/cached_shadows.cpp
@@ -62,7 +62,7 @@ namespace melatonin::internal
         renderInternal (g);
     }
 
-    void CachedShadows::render (juce::Graphics& g, const juce::Path& newPath, const juce::PathStrokeType& newType, const bool lowQuality)
+    void CachedShadows::render (juce::Graphics& g, const juce::Path& newPath, const juce::PathStrokeType& newType, const bool lowQuality, const juce::AffineTransform& transform)
     {
         if (renderedSingleChannelShadows.empty())
             return;
@@ -78,7 +78,7 @@ namespace melatonin::internal
         // Stroking the path changes its bounds.
         // Do this before we strip the origin and compare with cache.
         juce::Path strokedPath;
-        strokeType.createStrokedPath (strokedPath, newPath, {}, scale);
+        strokeType.createStrokedPath (strokedPath, newPath, transform, scale);
 
         updatePathIfNeeded (strokedPath);
 

--- a/melatonin/internal/cached_shadows.h
+++ b/melatonin/internal/cached_shadows.h
@@ -32,7 +32,7 @@ namespace melatonin::internal
         juce::Path lastOriginAgnosticPathScaled = {};
 
         void render (juce::Graphics& g, const juce::Path& newPath, bool lowQuality = false);
-        void render (juce::Graphics& g, const juce::Path& newPath, const juce::PathStrokeType& newType, bool lowQuality = false);
+        void render (juce::Graphics& g, const juce::Path& newPath, const juce::PathStrokeType& newType, bool lowQuality = false, const juce::AffineTransform& transform = {});
         void render (juce::Graphics& g, const juce::String& text, const juce::Rectangle<float>& area, juce::Justification justification);
         void render (juce::Graphics& g, const juce::String& text, const juce::Rectangle<int>& area, juce::Justification justification);
         void render (juce::Graphics& g, const juce::String& text, int x, int y, int width, int height, juce::Justification justification);


### PR DESCRIPTION
`juc::Graphics::strokePath()` lets you optionally provide a transform, so I'm adding that to the corresponding `shadow.render()` function as well.