### PR TITLE
Direct2D Take 2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
 
   BuildAndTest:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    name: Tests
+    name: Tests (${{ matrix.os }}, ${{ matrix.juce }}, Direct2D ${{ matrix.direct2d }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
 
@@ -38,10 +38,18 @@ jobs:
       matrix:
         os: [ macos-14, macos-26, windows-2022, ubuntu-22.04 ]
         juce: [ JUCE7, JUCE8 ]
+        direct2d: [ OFF ]
         exclude:
           # JUCE 7 uses CGWindowListCreateImage, unavailable on macOS 15+
           - os: macos-26
             juce: JUCE7
+        include:
+          - os: windows-2022
+            juce: JUCE8
+            direct2d: ON
+          - os: windows-2019
+            juce: JUCE8
+            direct2d: ON
 
     steps:
 
@@ -80,9 +88,9 @@ jobs:
       - name: Configure
         run: |
           if [ "${{ matrix.juce }}" == "JUCE7" ]; then
-            cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache . -DJUCE7=ON
+            cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache . -DJUCE7=ON -DMELATONIN_BLUR_USE_DIRECT2D=${{ matrix.direct2d }}
           else 
-            cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache .
+            cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache . -DMELATONIN_BLUR_USE_DIRECT2D=${{ matrix.direct2d }}
           fi
 
       - name: Build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,8 +55,6 @@ jobs:
 
       # Setup MSVC toolchain and developer command prompt (Windows)
       - uses: ilammy/msvc-dev-cmd@v1
-        with:
-          sdk: 10.0.22621.0
 
       # This block can be removed once 15.1 is default (JUCE requires it when building on macOS 14)
       - name: Use latest Xcode on system (macOS)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
           - os: windows-2022
             juce: JUCE8
             direct2d: ON
-          - os: windows-2019
+          - os: windows-2025
             juce: JUCE8
             direct2d: ON
 
@@ -100,6 +100,11 @@ jobs:
         working-directory: ${{ env.BUILD_DIR }}
         run: ./Tests
 
+      # Skipped when Direct2D is enabled: GitHub-hosted Windows runners have no
+      # GPU passthrough, so D2D falls back to WARP (software rendering). The numbers
+      # come back ~10× slower than the CPU path with variance exceeding the mean,
+      # which (a) isn't a useful signal and (b) blows past the job timeout.
       - name: Benchmarks
+        if: matrix.direct2d != 'ON'
         working-directory: ${{ env.BUILD_DIR }}
         run: ./Benchmarks

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,14 @@ project(MelatoninBlur VERSION 1.0.0 LANGUAGES C CXX
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
+if (WIN32)
+    set(MELATONIN_BLUR_USE_DIRECT2D_DEFAULT ON)
+else ()
+    set(MELATONIN_BLUR_USE_DIRECT2D_DEFAULT OFF)
+endif ()
+
+option(MELATONIN_BLUR_USE_DIRECT2D "Compile Direct2D support for melatonin_blur on Windows with JUCE 8+" ${MELATONIN_BLUR_USE_DIRECT2D_DEFAULT})
+
 include(FetchContent)
 if (MelatoninBlur_IS_TOP_LEVEL)
     option(JUCE7 "Run tests on JUCE 7" OFF)
@@ -47,6 +55,8 @@ if (MelatoninBlur_IS_TOP_LEVEL)
     target_include_directories(Benchmarks PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/source)
 
     juce_add_module("${CMAKE_CURRENT_SOURCE_DIR}")
+
+    target_compile_definitions(melatonin_blur INTERFACE MELATONIN_BLUR_USE_DIRECT2D=$<BOOL:${MELATONIN_BLUR_USE_DIRECT2D}>)
 
     target_link_libraries(Tests PRIVATE
         melatonin_blur
@@ -105,4 +115,6 @@ else ()
     endif ()
 
     juce_add_module("${CMAKE_CURRENT_SOURCE_DIR}")
+
+    target_compile_definitions(melatonin_blur INTERFACE MELATONIN_BLUR_USE_DIRECT2D=$<BOOL:${MELATONIN_BLUR_USE_DIRECT2D}>)
 endif ()

--- a/benchmarks/argb.cpp
+++ b/benchmarks/argb.cpp
@@ -39,7 +39,7 @@ TEST_CASE ("Melatonin Blur ARGB Benchmarks")
                     {
                         // uses a temp copy internally
                         melatonin::blur::argb (src, dst, radius);
-                        g.drawImageAt (src, 0, 0, true);
+                        g.drawImageAt (dst, 0, 0, true);
                         auto color = dstData.getPixelColour (20, 20);
                         return color;
                     };
@@ -56,10 +56,20 @@ TEST_CASE ("Melatonin Blur ARGB Benchmarks")
                     BENCHMARK ("Melatonin Cached")
                     {
                         // returns a juce::Image to render
-                        g.drawImageAt (blur.render (src), 0, 0, true);
+                        auto& rendered = blur.render (src);
+                        g.drawImageAt (rendered, 0, 0, true);
                         auto color = dstData.getPixelColour (20, 20);
                         return color;
                     };
+
+                   #if MELATONIN_BLUR_USE_DIRECT2D
+                    BENCHMARK ("Direct2D")
+                    {
+                        melatonin::blur::direct2DARGB (src, dst, radius);
+                        auto color = dstData.getPixelColour (20, 20);
+                        return color;
+                    };
+                   #endif
                 }
             }
         }

--- a/benchmarks/benchmark_helpers.h
+++ b/benchmarks/benchmark_helpers.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#if MELATONIN_BLUR_USE_DIRECT2D
+namespace
+{
+    struct ScopedDirect2DBenchmarkSetting
+    {
+        explicit ScopedDirect2DBenchmarkSetting (bool enabled)
+            : previous (melatonin::blur::isDirect2DEnabled())
+        {
+            melatonin::blur::setDirect2DEnabled (enabled);
+        }
+
+        ~ScopedDirect2DBenchmarkSetting()
+        {
+            melatonin::blur::setDirect2DEnabled (previous);
+        }
+
+        bool previous = false;
+    };
+}
+#endif

--- a/benchmarks/benchmark_helpers.h
+++ b/benchmarks/benchmark_helpers.h
@@ -1,5 +1,11 @@
 #pragma once
 
+// GitHub-hosted Windows runners have no GPU passthrough, so Direct2D falls back
+// to software rendering (WARP). In that environment D2D is ~10× slower than the
+// CPU path and the per-sample variance exceeds the mean — i.e. the numbers are
+// noise. The CI workflow skips the Benchmarks step when MELATONIN_BLUR_USE_DIRECT2D
+// is enabled for this reason; run benchmarks on real hardware to get a signal.
+
 #if MELATONIN_BLUR_USE_DIRECT2D
 namespace
 {

--- a/benchmarks/benchmarks.cpp
+++ b/benchmarks/benchmarks.cpp
@@ -7,6 +7,7 @@
 #include "../melatonin/implementations/naive.h"
 #include "../melatonin/implementations/float_vector_stack_blur.h"
 #include "../melatonin/internal/implementations.h"
+#include "benchmark_helpers.h"
 
 // other benchmarks
 #include "single_channel.cpp"

--- a/benchmarks/drop_shadow.cpp
+++ b/benchmarks/drop_shadow.cpp
@@ -5,15 +5,9 @@ TEST_CASE ("Melatonin Blur Drop Shadow Benchmarks")
         DYNAMIC_SECTION ("Path Size:" << dimension << "x" << dimension)
         {
             juce::Path p;
-            // 20x20 px rectangle in a 100x100 px image
             const auto pathSize = static_cast<float> (dimension);
             p.addRectangle (pathSize / 2.0f, pathSize / 2.0f, pathSize, pathSize);
 
-            // typical shadow example
-            melatonin::DropShadow shadow = {
-                { juce::Colours::red, 48, { 2, 2 } },
-                { juce::Colours::black, 36, { 0, 8 } }
-            };
             juce::Image image (juce::Image::PixelFormat::ARGB, dimension * 2, dimension * 2, true);
 
             // needed for JUCE not to pee its pants (aka leak) when working with graphics
@@ -23,7 +17,6 @@ TEST_CASE ("Melatonin Blur Drop Shadow Benchmarks")
 
             SECTION ("single render")
             {
-                shadow.render (g, p);
                 BENCHMARK ("Reference (gin)")
                 {
                     melatonin::stackBlur::renderDropShadow (g, p, juce::Colours::red, 48, { 2, 2 });
@@ -31,74 +24,76 @@ TEST_CASE ("Melatonin Blur Drop Shadow Benchmarks")
                     return image.getPixelAt (20, 20);
                 };
 
+                melatonin::DropShadow cachedShadow = {
+                    { juce::Colours::red, 48, { 2, 2 } },
+                    { juce::Colours::black, 36, { 0, 8 } }
+                };
+                melatonin::DropShadow uncachedShadow = {
+                    { juce::Colours::red, 48, { 2, 2 } },
+                    { juce::Colours::black, 36, { 0, 8 } }
+                };
+                uncachedShadow.setBypassCache (true);
+
                #if MELATONIN_BLUR_USE_DIRECT2D
-                juce::Path alternatePath;
-                alternatePath.addEllipse (pathSize / 2.0f, pathSize / 2.0f, pathSize, pathSize);
-
-                melatonin::DropShadow cpuShadow = {
+                melatonin::DropShadow cpuCachedShadow = {
                     { juce::Colours::red, 48, { 2, 2 } },
                     { juce::Colours::black, 36, { 0, 8 } }
                 };
-                melatonin::DropShadow direct2DShadow = {
+                melatonin::DropShadow cpuUncachedShadow = {
                     { juce::Colours::red, 48, { 2, 2 } },
                     { juce::Colours::black, 36, { 0, 8 } }
                 };
-                melatonin::DropShadow cpuRecalculatedShadow = {
-                    { juce::Colours::red, 48, { 2, 2 } },
-                    { juce::Colours::black, 36, { 0, 8 } }
-                };
-                melatonin::DropShadow direct2DRecalculatedShadow = {
-                    { juce::Colours::red, 48, { 2, 2 } },
-                    { juce::Colours::black, 36, { 0, 8 } }
-                };
+                cpuUncachedShadow.setBypassCache (true);
 
-                BENCHMARK_ADVANCED ("Melatonin (cached draw only, D2D runtime OFF / CPU)") (Catch::Benchmark::Chronometer meter)
-                {
-                    const ScopedDirect2DBenchmarkSetting mode (false);
-
-                    meter.measure ([&] {
-                        cpuShadow.render (g, p);
-                        return image.getPixelAt (20, 20);
-                    });
-                };
-
-                BENCHMARK_ADVANCED ("Melatonin (cached draw only, D2D runtime ON)") (Catch::Benchmark::Chronometer meter)
+                BENCHMARK_ADVANCED ("Melatonin (cached)") (Catch::Benchmark::Chronometer meter)
                 {
                     const ScopedDirect2DBenchmarkSetting mode (true);
 
                     meter.measure ([&] {
-                        direct2DShadow.render (g, p);
+                        cachedShadow.render (g, p);
                         return image.getPixelAt (20, 20);
                     });
                 };
 
-                BENCHMARK_ADVANCED ("Melatonin (rebuild blur, D2D runtime OFF / CPU)") (Catch::Benchmark::Chronometer meter)
-                {
-                    const ScopedDirect2DBenchmarkSetting mode (false);
-                    auto useAlternatePath = false;
-
-                    meter.measure ([&] {
-                        useAlternatePath = ! useAlternatePath;
-                        cpuRecalculatedShadow.render (g, useAlternatePath ? p : alternatePath);
-                        return image.getPixelAt (20, 20);
-                    });
-                };
-
-                BENCHMARK_ADVANCED ("Melatonin (rebuild blur, D2D runtime ON)") (Catch::Benchmark::Chronometer meter)
+                BENCHMARK_ADVANCED ("Melatonin (uncached)") (Catch::Benchmark::Chronometer meter)
                 {
                     const ScopedDirect2DBenchmarkSetting mode (true);
-                    auto useAlternatePath = false;
 
                     meter.measure ([&] {
-                        useAlternatePath = ! useAlternatePath;
-                        direct2DRecalculatedShadow.render (g, useAlternatePath ? p : alternatePath);
+                        uncachedShadow.render (g, p);
+                        return image.getPixelAt (20, 20);
+                    });
+                };
+
+                BENCHMARK_ADVANCED ("Melatonin D2D OFF / CPU fallback (cached)") (Catch::Benchmark::Chronometer meter)
+                {
+                    const ScopedDirect2DBenchmarkSetting mode (false);
+
+                    meter.measure ([&] {
+                        cpuCachedShadow.render (g, p);
+                        return image.getPixelAt (20, 20);
+                    });
+                };
+
+                BENCHMARK_ADVANCED ("Melatonin D2D OFF / CPU fallback (uncached)") (Catch::Benchmark::Chronometer meter)
+                {
+                    const ScopedDirect2DBenchmarkSetting mode (false);
+
+                    meter.measure ([&] {
+                        cpuUncachedShadow.render (g, p);
                         return image.getPixelAt (20, 20);
                     });
                 };
                #else
                 BENCHMARK ("Melatonin (cached)")
                 {
-                    shadow.render (g, p);
+                    cachedShadow.render (g, p);
+                    return image.getPixelAt (20, 20);
+                };
+
+                BENCHMARK ("Melatonin (uncached)")
+                {
+                    uncachedShadow.render (g, p);
                     return image.getPixelAt (20, 20);
                 };
                #endif

--- a/benchmarks/drop_shadow.cpp
+++ b/benchmarks/drop_shadow.cpp
@@ -6,7 +6,8 @@ TEST_CASE ("Melatonin Blur Drop Shadow Benchmarks")
         {
             juce::Path p;
             // 20x20 px rectangle in a 100x100 px image
-            p.addRectangle (dimension / 2, dimension / 2, dimension, dimension);
+            const auto pathSize = static_cast<float> (dimension);
+            p.addRectangle (pathSize / 2.0f, pathSize / 2.0f, pathSize, pathSize);
 
             // typical shadow example
             melatonin::DropShadow shadow = {
@@ -30,11 +31,77 @@ TEST_CASE ("Melatonin Blur Drop Shadow Benchmarks")
                     return image.getPixelAt (20, 20);
                 };
 
+               #if MELATONIN_BLUR_USE_DIRECT2D
+                juce::Path alternatePath;
+                alternatePath.addEllipse (pathSize / 2.0f, pathSize / 2.0f, pathSize, pathSize);
+
+                melatonin::DropShadow cpuShadow = {
+                    { juce::Colours::red, 48, { 2, 2 } },
+                    { juce::Colours::black, 36, { 0, 8 } }
+                };
+                melatonin::DropShadow direct2DShadow = {
+                    { juce::Colours::red, 48, { 2, 2 } },
+                    { juce::Colours::black, 36, { 0, 8 } }
+                };
+                melatonin::DropShadow cpuRecalculatedShadow = {
+                    { juce::Colours::red, 48, { 2, 2 } },
+                    { juce::Colours::black, 36, { 0, 8 } }
+                };
+                melatonin::DropShadow direct2DRecalculatedShadow = {
+                    { juce::Colours::red, 48, { 2, 2 } },
+                    { juce::Colours::black, 36, { 0, 8 } }
+                };
+
+                BENCHMARK_ADVANCED ("Melatonin (cached draw only, D2D runtime OFF / CPU)") (Catch::Benchmark::Chronometer meter)
+                {
+                    const ScopedDirect2DBenchmarkSetting mode (false);
+
+                    meter.measure ([&] {
+                        cpuShadow.render (g, p);
+                        return image.getPixelAt (20, 20);
+                    });
+                };
+
+                BENCHMARK_ADVANCED ("Melatonin (cached draw only, D2D runtime ON)") (Catch::Benchmark::Chronometer meter)
+                {
+                    const ScopedDirect2DBenchmarkSetting mode (true);
+
+                    meter.measure ([&] {
+                        direct2DShadow.render (g, p);
+                        return image.getPixelAt (20, 20);
+                    });
+                };
+
+                BENCHMARK_ADVANCED ("Melatonin (rebuild blur, D2D runtime OFF / CPU)") (Catch::Benchmark::Chronometer meter)
+                {
+                    const ScopedDirect2DBenchmarkSetting mode (false);
+                    auto useAlternatePath = false;
+
+                    meter.measure ([&] {
+                        useAlternatePath = ! useAlternatePath;
+                        cpuRecalculatedShadow.render (g, useAlternatePath ? p : alternatePath);
+                        return image.getPixelAt (20, 20);
+                    });
+                };
+
+                BENCHMARK_ADVANCED ("Melatonin (rebuild blur, D2D runtime ON)") (Catch::Benchmark::Chronometer meter)
+                {
+                    const ScopedDirect2DBenchmarkSetting mode (true);
+                    auto useAlternatePath = false;
+
+                    meter.measure ([&] {
+                        useAlternatePath = ! useAlternatePath;
+                        direct2DRecalculatedShadow.render (g, useAlternatePath ? p : alternatePath);
+                        return image.getPixelAt (20, 20);
+                    });
+                };
+               #else
                 BENCHMARK ("Melatonin (cached)")
                 {
                     shadow.render (g, p);
                     return image.getPixelAt (20, 20);
                 };
+               #endif
 
                 BENCHMARK ("juce")
                 {

--- a/benchmarks/single_channel.cpp
+++ b/benchmarks/single_channel.cpp
@@ -1,11 +1,18 @@
 TEST_CASE ("Melatonin Blur Single Channel Benchmarks")
 {
+    auto createSource = [] (int dimension) {
+        juce::Image image (juce::Image::PixelFormat::SingleChannel, dimension, dimension, true);
+        juce::Graphics g (image);
+        g.setColour (juce::Colours::white);
+        g.fillRect (dimension / 4, dimension / 4, dimension / 2, dimension / 2);
+        return image;
+    };
+
     for (auto dimension : { 50, 100, 200, 500, 1000 })
     {
         DYNAMIC_SECTION ("Single Channel, Image Size " << dimension << "x" << dimension)
         {
-            juce::Image image (juce::Image::PixelFormat::SingleChannel, dimension, dimension, true);
-            juce::Image::BitmapData data (image, juce::Image::BitmapData::readOnly);
+            juce::ScopedJuceInitialiser_GUI juce;
 
             for (auto radius : { 5, 10, 15, 20, 50 })
             {
@@ -14,6 +21,20 @@ TEST_CASE ("Melatonin Blur Single Channel Benchmarks")
 
                 DYNAMIC_SECTION ("with radius " << radius)
                 {
+                    auto ginImage = createSource (dimension);
+                    auto naiveImage = createSource (dimension);
+                    auto floatVectorImage = createSource (dimension);
+
+                   #if MELATONIN_BLUR_USE_DIRECT2D
+                    auto cpuFallbackImage = createSource (dimension);
+                    auto direct2DSrc = createSource (dimension);
+                    auto direct2DDst = createSource (dimension);
+                    melatonin::blur::Direct2DSingleChannelBlur direct2DBlur;
+                    direct2DBlur.render (direct2DSrc, direct2DDst, (size_t) radius);
+                   #else
+                    auto melatoninImage = createSource (dimension);
+                   #endif
+
                     //                    BENCHMARK ("dequeue")
                     //                    {
                     //                        melatonin::stackBlur::dequeueSingleChannel (image, radius);
@@ -24,16 +45,14 @@ TEST_CASE ("Melatonin Blur Single Channel Benchmarks")
 
                     BENCHMARK ("Gin (reference implementation)")
                     {
-                        melatonin::stackBlur::ginSingleChannel (image, radius);
-                        auto color = data.getPixelColour (dimension - radius, dimension - radius);
-                        return color;
+                        melatonin::stackBlur::ginSingleChannel (ginImage, radius);
+                        return ginImage.getWidth();
                     };
 
                     BENCHMARK ("Naive (Circular Buffer)")
                     {
-                        melatonin::stackBlur::circularBufferSingleChannel (image, radius);
-                        auto color = data.getPixelColour (dimension - radius, dimension - radius);
-                        return color;
+                        melatonin::stackBlur::circularBufferSingleChannel (naiveImage, radius);
+                        return naiveImage.getWidth();
                     };
 
                     //                    BENCHMARK ("Tent")
@@ -72,17 +91,37 @@ TEST_CASE ("Melatonin Blur Single Channel Benchmarks")
 
                     BENCHMARK ("JUCE FloatVectorOperations")
                     {
-                        melatonin::blur::juceFloatVectorSingleChannel (image, radius);
-                        auto color = data.getPixelColour (dimension - radius, dimension - radius);
-                        return color;
+                        melatonin::blur::juceFloatVectorSingleChannel (floatVectorImage, radius);
+                        return floatVectorImage.getWidth();
                     };
 
+                   #if MELATONIN_BLUR_USE_DIRECT2D
+                    BENCHMARK_ADVANCED ("Melatonin CPU fallback (D2D runtime OFF)") (Catch::Benchmark::Chronometer meter)
+                    {
+                        const ScopedDirect2DBenchmarkSetting mode (false);
+
+                        meter.measure ([&] {
+                            melatonin::blur::cpuSingleChannel (cpuFallbackImage, radius);
+                            return cpuFallbackImage.getWidth();
+                        });
+                    };
+
+                    BENCHMARK_ADVANCED ("Direct2D source-to-dest (reused renderer)") (Catch::Benchmark::Chronometer meter)
+                    {
+                        const ScopedDirect2DBenchmarkSetting mode (true);
+
+                        meter.measure ([&] {
+                            direct2DBlur.render (direct2DSrc, direct2DDst, (size_t) radius);
+                            return direct2DDst.getWidth();
+                        });
+                    };
+                   #else
                     BENCHMARK ("Melatonin")
                     {
-                        melatonin::blur::singleChannel (image, radius);
-                        auto color = data.getPixelColour (dimension - radius, dimension - radius);
-                        return color;
+                        melatonin::blur::singleChannel (melatoninImage, radius);
+                        return melatoninImage.getWidth();
                     };
+                   #endif
                 }
             }
         }

--- a/melatonin/blur_demo_component.h
+++ b/melatonin/blur_demo_component.h
@@ -30,6 +30,35 @@ namespace melatonin
             addAndMakeVisible (colorSelector);
             addAndMakeVisible (animateButton);
             addAndMakeVisible (resetButton);
+            addAndMakeVisible (bypassCacheToggle);
+            addAndMakeVisible (textShadowsToggle);
+
+#if MELATONIN_BLUR_USE_DIRECT2D
+            addAndMakeVisible (direct2DToggle);
+            direct2DToggle.setToggleState (melatonin::blur::isDirect2DEnabled(), juce::dontSendNotification);
+            direct2DToggle.setColour (juce::ToggleButton::textColourId, juce::Colours::white);
+            direct2DToggle.onClick = [this] {
+                melatonin::blur::setDirect2DEnabled (direct2DToggle.getToggleState());
+                skipNextPerfSample = true;
+                repaint();
+            };
+#endif
+
+            bypassCacheToggle.setColour (juce::ToggleButton::textColourId, juce::Colours::white);
+            bypassCacheToggle.onClick = [this] {
+                const auto b = bypassCacheToggle.getToggleState();
+                dropShadow.setBypassCache (b);
+                innerShadow.setBypassCache (b);
+                strokedDropShadow.setBypassCache (b);
+                strokedInnerShadow.setBypassCache (b);
+                textDropShadow.setBypassCache (b);
+                textInnerShadow.setBypassCache (b);
+                repaint();
+            };
+
+            textShadowsToggle.setToggleState (true, juce::dontSendNotification);
+            textShadowsToggle.setColour (juce::ToggleButton::textColourId, juce::Colours::white);
+            textShadowsToggle.onClick = [this] { repaint(); };
 
             radiusSlider.setColour (juce::Slider::ColourIds::trackColourId, juce::Colours::grey);
             spreadSlider.setColour (juce::Slider::ColourIds::trackColourId, juce::Colours::grey);
@@ -159,15 +188,19 @@ namespace melatonin
             g.strokePath (strokedInnerPath, juce::PathStrokeType (6));
             strokedInnerShadow.render (g, strokedInnerPath, juce::PathStrokeType (6));
 
-            g.setColour (juce::Colours::white);
-            g.setFont (g.getCurrentFont().withHeight (50).boldened());
-            textDropShadow.render (g, "drop", textBounds, juce::Justification::left);
-            g.drawText ("drop", textBounds, juce::Justification::left);
+            if (textShadowsToggle.getToggleState())
+            {
+                g.setColour (juce::Colours::white);
+                g.setFont (g.getCurrentFont().withHeight (50).boldened());
+                textDropShadow.render (g, "drop", textBounds, juce::Justification::left);
+                g.drawText ("drop", textBounds, juce::Justification::left);
 
-            g.drawText ("inner", textBounds, juce::Justification::centredRight);
-            textInnerShadow.render (g, "inner", textBounds.toFloat(), juce::Justification::centredRight);
+                g.drawText ("inner", textBounds, juce::Justification::centredRight);
+                textInnerShadow.render (g, "inner", textBounds.toFloat(), juce::Justification::centredRight);
+            }
 
             g.setFont (16);
+            g.setColour (juce::Colours::white);
             auto labels = juce::StringArray ("radius", "spread", "offsetX", "offsetY", "opacity");
             for (auto i = 0; i < labels.size(); ++i)
             {
@@ -175,10 +208,21 @@ namespace melatonin
             }
             auto elapsed = (float) (juce::Time::getMillisecondCounterHiRes() - start);
 
-            perfHistory[perfWriteIndex] = { elapsed, perfRng.nextFloat() };
-            perfWriteIndex = (perfWriteIndex + 1) % kPerfHistorySize;
-            if (perfFilled < kPerfHistorySize)
-                ++perfFilled;
+            // After the D2D backend is flipped, the very next paint pays a one-shot
+            // recalc cost across every cached shadow. Recording that single outlier
+            // would shoot maxMs through the roof and squash all subsequent samples
+            // into the floor of the graph, so we drop just that one frame.
+            if (skipNextPerfSample)
+            {
+                skipNextPerfSample = false;
+            }
+            else
+            {
+                perfHistory[perfWriteIndex] = { elapsed, perfRng.nextFloat() };
+                perfWriteIndex = (perfWriteIndex + 1) % kPerfHistorySize;
+                if (perfFilled < kPerfHistorySize)
+                    ++perfFilled;
+            }
 
             auto topStrip = getLocalBounds().removeFromTop (80);
             auto headerArea = topStrip.removeFromTop (24);
@@ -188,15 +232,33 @@ namespace melatonin
             drawPerfGraph (g, topStrip);
         }
 
-        static juce::String formatTime (float ms)
+        // U+00B5 (micro sign) as explicit UTF-8 bytes. Avoids MSVC narrow-literal
+        // encoding ambiguity that asserts inside juce::String when the source file
+        // isn't read as UTF-8.
+        static juce::String microsSuffix()
         {
-            return juce::String (juce::roundToInt (ms * 1000.0f)) + "µs";
+            return juce::String (juce::CharPointer_UTF8 ("\xc2\xb5s"));
+        }
+
+        // scaleMs (the axis maximum) chooses the unit so every label on the axis
+        // is in the same one — mixing "400µs" and "1.5ms" labels in the same graph
+        // looks worse than just picking ms when the range exceeds 1ms.
+        // Always one decimal place when in ms: juce::String(float, 0) means
+        // "default precision" in JUCE (i.e. many digits), not "zero decimals".
+        static juce::String formatTime (float ms, float scaleMs)
+        {
+            if (scaleMs >= 1.0f)
+                return juce::String (ms, 1) + "ms";
+            return juce::String (juce::roundToInt (ms * 1000.0f)) + microsSuffix();
         }
 
         void drawPerfGraph (juce::Graphics& g, juce::Rectangle<int> bounds)
         {
             auto labelArea = bounds.removeFromBottom (14);
-            auto graphArea = bounds.reduced (4, 4);
+            // Reserve enough horizontal space on either side of the graph for
+            // the "0" / max axis labels (placed at graphArea.getX() - 40 and
+            // graphArea.getRight() + 2 respectively), otherwise they get clipped.
+            auto graphArea = bounds.reduced (4, 4).withTrimmedLeft (40).withTrimmedRight (62);
 
             float maxMs = 0.001f;
             for (size_t i = 0; i < perfFilled; ++i)
@@ -204,8 +266,8 @@ namespace melatonin
 
             g.setFont (11.0f);
             g.setColour (juce::Colours::white.withAlpha (0.55f));
-            g.drawText ("0µs", juce::Rectangle<int> (graphArea.getX() - 40, labelArea.getY(), 38, labelArea.getHeight()), juce::Justification::centredRight);
-            g.drawText (formatTime (maxMs), juce::Rectangle<int> (graphArea.getRight() + 2, labelArea.getY(), 60, labelArea.getHeight()), juce::Justification::centredLeft);
+            g.drawText (formatTime (0.0f, maxMs), juce::Rectangle<int> (graphArea.getX() - 40, labelArea.getY(), 38, labelArea.getHeight()), juce::Justification::centredRight);
+            g.drawText (formatTime (maxMs, maxMs), juce::Rectangle<int> (graphArea.getRight() + 2, labelArea.getY(), 60, labelArea.getHeight()), juce::Justification::centredLeft);
 
             g.setColour (juce::Colours::white.withAlpha (0.35f));
             constexpr int numIntermediate = 5;
@@ -214,7 +276,7 @@ namespace melatonin
                 auto t = (float) i / (float) (numIntermediate + 1);
                 auto x = juce::roundToInt (juce::jmap (t, (float) graphArea.getX(), (float) graphArea.getRight()));
                 g.fillRect (x, graphArea.getBottom() - 3, 1, 3);
-                g.drawText (formatTime (t * maxMs), juce::Rectangle<int> (x - 30, labelArea.getY(), 60, labelArea.getHeight()), juce::Justification::centred);
+                g.drawText (formatTime (t * maxMs, maxMs), juce::Rectangle<int> (x - 30, labelArea.getY(), 60, labelArea.getHeight()), juce::Justification::centred);
             }
 
             g.setColour (juce::Colours::white.withAlpha (0.12f));
@@ -285,6 +347,20 @@ namespace melatonin
             resetButton.setBounds (buttonRow.removeFromLeft (100));
             buttonRow.removeFromLeft (10);
             animateButton.setBounds (buttonRow.removeFromLeft (100));
+
+#if MELATONIN_BLUR_USE_DIRECT2D
+            auto toggleRow = area.removeFromTop (30).withSizeKeepingCentre (440, 24);
+            direct2DToggle.setBounds (toggleRow.removeFromLeft (110));
+            toggleRow.removeFromLeft (10);
+            bypassCacheToggle.setBounds (toggleRow.removeFromLeft (140));
+            toggleRow.removeFromLeft (10);
+            textShadowsToggle.setBounds (toggleRow.removeFromLeft (170));
+#else
+            auto toggleRow = area.removeFromTop (30).withSizeKeepingCentre (320, 24);
+            bypassCacheToggle.setBounds (toggleRow.removeFromLeft (140));
+            toggleRow.removeFromLeft (10);
+            textShadowsToggle.setBounds (toggleRow.removeFromLeft (170));
+#endif
         }
 
         void changeListenerCallback (juce::ChangeBroadcaster* source) override
@@ -333,6 +409,11 @@ namespace melatonin
             0 };
         juce::TextButton animateButton { "Animate!" };
         juce::TextButton resetButton { "Reset" };
+        juce::ToggleButton bypassCacheToggle { "Uncached only" };
+        juce::ToggleButton textShadowsToggle { "text drop/inner" };
+#if MELATONIN_BLUR_USE_DIRECT2D
+        juce::ToggleButton direct2DToggle { "Direct2D" };
+#endif
 #if MELATONIN_VBLANK
         juce::VBlankAttachment vBlankCallback;
 #endif
@@ -343,6 +424,7 @@ namespace melatonin
         std::array<PerfSample, kPerfHistorySize> perfHistory {};
         size_t perfWriteIndex = 0;
         size_t perfFilled = 0;
+        bool skipNextPerfSample = false;
         juce::Random perfRng;
     };
 

--- a/melatonin/blur_demo_component.h
+++ b/melatonin/blur_demo_component.h
@@ -29,6 +29,7 @@ namespace melatonin
             addAndMakeVisible (opacitySlider);
             addAndMakeVisible (colorSelector);
             addAndMakeVisible (animateButton);
+            addAndMakeVisible (resetButton);
 
             radiusSlider.setColour (juce::Slider::ColourIds::trackColourId, juce::Colours::grey);
             spreadSlider.setColour (juce::Slider::ColourIds::trackColourId, juce::Colours::grey);
@@ -110,6 +111,17 @@ namespace melatonin
                 animating = !animating;
                 animateButton.setButtonText (animating ? "Stop!" : "Animate!");
             };
+
+            resetButton.onClick = [this] {
+                animating = false;
+                animateButton.setButtonText ("Animate!");
+                modulator = 0;
+                radiusSlider.setValue (10);
+                spreadSlider.setValue (0);
+                offsetXSlider.setValue (0);
+                offsetYSlider.setValue (0);
+                opacitySlider.setValue (1);
+            };
         }
 
         void modulate()
@@ -161,16 +173,80 @@ namespace melatonin
             {
                 g.drawText (labels[i], sliderLabelsBounds.withLeft (sliderLabelsBounds.getX() + 60 * i).withWidth (60), juce::Justification::centred);
             }
-            auto elapsed = juce::Time::getMillisecondCounterHiRes() - start;
+            auto elapsed = (float) (juce::Time::getMillisecondCounterHiRes() - start);
 
-            g.setColour (juce::Colours::white);
-            g.setFont (20);
-            g.drawText ("rendered in " + juce::String (elapsed, 3) + "ms", getLocalBounds().removeFromTop (50), juce::Justification::centred);
+            perfHistory[perfWriteIndex] = { elapsed, perfRng.nextFloat() };
+            perfWriteIndex = (perfWriteIndex + 1) % kPerfHistorySize;
+            if (perfFilled < kPerfHistorySize)
+                ++perfFilled;
+
+            auto topStrip = getLocalBounds().removeFromTop (80);
+            auto headerArea = topStrip.removeFromTop (24);
+            g.setColour (juce::Colours::white.withAlpha (0.75f));
+            g.setFont (13.0f);
+            g.drawText ("paint durations history", headerArea, juce::Justification::centred);
+            drawPerfGraph (g, topStrip);
+        }
+
+        static juce::String formatTime (float ms)
+        {
+            return juce::String (juce::roundToInt (ms * 1000.0f)) + "µs";
+        }
+
+        void drawPerfGraph (juce::Graphics& g, juce::Rectangle<int> bounds)
+        {
+            auto labelArea = bounds.removeFromBottom (14);
+            auto graphArea = bounds.reduced (4, 4);
+
+            float maxMs = 0.001f;
+            for (size_t i = 0; i < perfFilled; ++i)
+                maxMs = std::max (maxMs, perfHistory[i].elapsedMs);
+
+            g.setFont (11.0f);
+            g.setColour (juce::Colours::white.withAlpha (0.55f));
+            g.drawText ("0µs", juce::Rectangle<int> (graphArea.getX() - 40, labelArea.getY(), 38, labelArea.getHeight()), juce::Justification::centredRight);
+            g.drawText (formatTime (maxMs), juce::Rectangle<int> (graphArea.getRight() + 2, labelArea.getY(), 60, labelArea.getHeight()), juce::Justification::centredLeft);
+
+            g.setColour (juce::Colours::white.withAlpha (0.35f));
+            constexpr int numIntermediate = 5;
+            for (int i = 1; i <= numIntermediate; ++i)
+            {
+                auto t = (float) i / (float) (numIntermediate + 1);
+                auto x = juce::roundToInt (juce::jmap (t, (float) graphArea.getX(), (float) graphArea.getRight()));
+                g.fillRect (x, graphArea.getBottom() - 3, 1, 3);
+                g.drawText (formatTime (t * maxMs), juce::Rectangle<int> (x - 30, labelArea.getY(), 60, labelArea.getHeight()), juce::Justification::centred);
+            }
+
+            g.setColour (juce::Colours::white.withAlpha (0.12f));
+            g.fillRect (graphArea.getX(), graphArea.getBottom() - 1, graphArea.getWidth(), 1);
+
+            const auto liveColor = juce::Colour::fromRGB (120, 220, 180);
+            const auto fadedColor = juce::Colour::fromRGB (110, 140, 125);
+            const auto deadColor = juce::Colours::grey.withAlpha (0.45f);
+            const auto graphTop = (float) graphArea.getY();
+            const auto graphHeight = (float) graphArea.getHeight() - 4.0f;
+            const auto graphX = (float) graphArea.getX();
+            const auto graphWidth = (float) graphArea.getWidth();
+
+            for (size_t i = 0; i < perfFilled; ++i)
+            {
+                auto idx = (perfWriteIndex + kPerfHistorySize - perfFilled + i) % kPerfHistorySize;
+                const auto& s = perfHistory[idx];
+                auto age = perfFilled - 1 - i;
+
+                auto xNorm = std::min (1.0f, s.elapsedMs / maxMs);
+                auto x = graphX + xNorm * graphWidth;
+                auto y = graphTop + s.yJitter * graphHeight;
+
+                g.setColour (age < 60 ? liveColor : age < 120 ? fadedColor : deadColor);
+                g.fillEllipse (x - 1.5f, y - 1.5f, 3.0f, 3.0f);
+            }
         }
 
         void resized() override
         {
             auto area = getLocalBounds().reduced (50);
+            area.removeFromTop (30);
             contentBounds = area.removeFromTop (150).withSizeKeepingCentre (550, 100);
             dropShadowedPath.clear();
             dropShadowedPath.addRoundedRectangle (contentBounds.removeFromLeft (100), 10);
@@ -205,7 +281,10 @@ namespace melatonin
             area.removeFromTop (10);
 
             colorSelector.setBounds (area.removeFromTop (200).withSizeKeepingCentre (200, 200));
-            animateButton.setBounds (area.removeFromTop (50).withSizeKeepingCentre (100, 30));
+            auto buttonRow = area.removeFromTop (50).withSizeKeepingCentre (210, 30);
+            resetButton.setBounds (buttonRow.removeFromLeft (100));
+            buttonRow.removeFromLeft (10);
+            animateButton.setBounds (buttonRow.removeFromLeft (100));
         }
 
         void changeListenerCallback (juce::ChangeBroadcaster* source) override
@@ -253,10 +332,18 @@ namespace melatonin
             0,
             0 };
         juce::TextButton animateButton { "Animate!" };
+        juce::TextButton resetButton { "Reset" };
 #if MELATONIN_VBLANK
         juce::VBlankAttachment vBlankCallback;
 #endif
         size_t modulator = 0;
+
+        struct PerfSample { float elapsedMs; float yJitter; };
+        static constexpr size_t kPerfHistorySize = 300;
+        std::array<PerfSample, kPerfHistorySize> perfHistory {};
+        size_t perfWriteIndex = 0;
+        size_t perfFilled = 0;
+        juce::Random perfRng;
     };
 
     class TextShadowDemo : public juce::Component

--- a/melatonin/blur_options.h
+++ b/melatonin/blur_options.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "juce_graphics/juce_graphics.h"
+
+// CMake (or user) opts in/out. Default on; the platform check below gates it.
+#ifndef MELATONIN_BLUR_USE_DIRECT2D
+ #define MELATONIN_BLUR_USE_DIRECT2D 1
+#endif
+
+// Direct2D only exists on Windows + JUCE 8, so AND the platform in here once
+// so every call site can just do `#if MELATONIN_BLUR_USE_DIRECT2D`.
+#if MELATONIN_BLUR_USE_DIRECT2D && JUCE_WINDOWS && JUCE_MAJOR_VERSION >= 8
+ #undef MELATONIN_BLUR_USE_DIRECT2D
+ #define MELATONIN_BLUR_USE_DIRECT2D 1
+#else
+ #undef MELATONIN_BLUR_USE_DIRECT2D
+ #define MELATONIN_BLUR_USE_DIRECT2D 0
+#endif
+
+namespace melatonin::blur
+{
+   #if MELATONIN_BLUR_USE_DIRECT2D
+    inline std::atomic<bool>& direct2DEnabledState()
+    {
+        static std::atomic<bool> enabled { true };
+        return enabled;
+    }
+
+    inline void setDirect2DEnabled (bool enabled)
+    {
+        direct2DEnabledState().store (enabled);
+    }
+
+    [[nodiscard]] inline bool isDirect2DEnabled()
+    {
+        return direct2DEnabledState().load();
+    }
+   #else
+    inline void setDirect2DEnabled (bool) {}
+
+    [[nodiscard]] inline bool isDirect2DEnabled()
+    {
+        return false;
+    }
+   #endif
+}

--- a/melatonin/blur_options.h
+++ b/melatonin/blur_options.h
@@ -26,14 +26,29 @@ namespace melatonin::blur
         return enabled;
     }
 
+    // Monotonic counter bumped whenever the D2D enabled state actually changes.
+    // CachedShadows uses this to self-invalidate so the next render() picks up
+    // the new backend without callers needing to clear caches themselves.
+    inline std::atomic<std::uint64_t>& direct2DGenerationCounter()
+    {
+        static std::atomic<std::uint64_t> gen { 0 };
+        return gen;
+    }
+
     inline void setDirect2DEnabled (bool enabled)
     {
-        direct2DEnabledState().store (enabled);
+        if (direct2DEnabledState().exchange (enabled) != enabled)
+            direct2DGenerationCounter().fetch_add (1, std::memory_order_relaxed);
     }
 
     [[nodiscard]] inline bool isDirect2DEnabled()
     {
         return direct2DEnabledState().load();
+    }
+
+    [[nodiscard]] inline std::uint64_t direct2DConfigGeneration()
+    {
+        return direct2DGenerationCounter().load (std::memory_order_relaxed);
     }
    #else
     inline void setDirect2DEnabled (bool) {}
@@ -41,6 +56,11 @@ namespace melatonin::blur
     [[nodiscard]] inline bool isDirect2DEnabled()
     {
         return false;
+    }
+
+    [[nodiscard]] inline std::uint64_t direct2DConfigGeneration()
+    {
+        return 0;
     }
    #endif
 }

--- a/melatonin/implementations/direct2d.cpp
+++ b/melatonin/implementations/direct2d.cpp
@@ -1,0 +1,382 @@
+#include "direct2d.h"
+
+#if MELATONIN_BLUR_USE_DIRECT2D
+
+JUCE_BEGIN_IGNORE_WARNINGS_MSVC (4458)
+ #ifndef NOMINMAX
+  #define NOMINMAX
+ #endif
+ #include <d2d1_3.h>
+ #include <d2d1effects.h>
+ #include <d3d11_2.h>
+ #include <dcomp.h>
+ #include <dwrite_3.h>
+ #include <dxgi1_3.h>
+ #include <processthreadsapi.h>
+JUCE_END_IGNORE_WARNINGS_MSVC
+
+#undef min
+#undef max
+
+#include "juce_core/native/juce_ComSmartPtr_windows.h"
+#include "juce_graphics/native/juce_Direct2DMetrics_windows.h"
+#include "juce_graphics/native/juce_Direct2DGraphicsContext_windows.h"
+#include "juce_graphics/native/juce_Direct2DPixelDataPage_windows.h"
+#include "juce_graphics/images/juce_ImagePixelDataNativeExtensions.h"
+#include "juce_graphics/native/juce_DirectX_windows.h"
+#include "juce_graphics/native/juce_Direct2DImageContext_windows.h"
+
+namespace melatonin::blur
+{
+    namespace
+    {
+        juce::ComSmartPtr<ID2D1Device1> getDefaultDevice()
+        {
+            juce::SharedResourcePointer<juce::DirectX> directX;
+
+            if (auto adapter = directX->adapters.getDefaultAdapter())
+                return adapter->direct2DDevice;
+
+            return nullptr;
+        }
+
+        bool getSinglePage (juce::Image& image,
+                            juce::ComSmartPtr<ID2D1Device1> device,
+                            juce::Direct2DPixelDataPage& page)
+        {
+            auto pages = image.getPixelData()->getNativeExtensions().getPages (device);
+
+            if (pages.size() != 1 || pages.front().bitmap == nullptr)
+                return false;
+
+            page = pages.front();
+            return true;
+        }
+
+        bool setKernelMatrix (juce::ComSmartPtr<ID2D1Effect> effect, size_t radius, bool horizontal)
+        {
+            const auto kernelRadius = juce::jmax ((size_t) 1, radius);
+            const auto kernelSize = 2 * kernelRadius + 1;
+            const auto divisor = (float) ((kernelRadius + 1) * (kernelRadius + 1));
+            std::vector<FLOAT> kernel (kernelSize);
+
+            for (size_t i = 0; i < kernelSize; ++i)
+                kernel[i] = (float) (kernelRadius + 1 - (size_t) std::abs ((int) i - (int) kernelRadius)) / divisor;
+
+            auto hr = effect->SetValue (D2D1_CONVOLVEMATRIX_PROP_KERNEL_SIZE_X, (UINT32) (horizontal ? kernelSize : 1));
+            hr |= effect->SetValue (D2D1_CONVOLVEMATRIX_PROP_KERNEL_SIZE_Y, (UINT32) (horizontal ? 1 : kernelSize));
+            hr |= effect->SetValue (D2D1_CONVOLVEMATRIX_PROP_KERNEL_MATRIX,
+                                    reinterpret_cast<const BYTE*> (kernel.data()),
+                                    (UINT32) (kernel.size() * sizeof (FLOAT)));
+            hr |= effect->SetValue (D2D1_CONVOLVEMATRIX_PROP_SCALE_MODE, D2D1_CONVOLVEMATRIX_SCALE_MODE_NEAREST_NEIGHBOR);
+            return SUCCEEDED (hr);
+        }
+
+        // Owns the D2D device + device context for a blur. Both blur classes need
+        // the same plumbing — this lets them share it without coupling their effects.
+        struct Direct2DContext
+        {
+            juce::ComSmartPtr<ID2D1Device1>        device;
+            juce::ComSmartPtr<ID2D1DeviceContext1> context;
+
+            enum class State { failed, unchanged, recreated };
+
+            // Returns recreated when the underlying device changed — callers must
+            // throw away any effects they cached against the previous context.
+            State ensure()
+            {
+                const auto defaultDevice = getDefaultDevice();
+                if (defaultDevice == nullptr)
+                    return State::failed;
+
+                // Pointer equality is safe: getDefaultDevice() always returns the
+                // singleton owned by juce::SharedResourcePointer<juce::DirectX>.
+                if (device.get() == defaultDevice.get() && context != nullptr)
+                    return State::unchanged;
+
+                reset();
+                device = defaultDevice;
+                context = juce::Direct2DDeviceContext::create (device);
+                return context != nullptr ? State::recreated : State::failed;
+            }
+
+            void reset()
+            {
+                context = {};
+                device = {};
+            }
+        };
+    }
+
+    struct Direct2DSingleChannelBlur::Pimpl
+    {
+        bool render (juce::Image& srcImage, juce::Image& dstImage, size_t radius)
+        {
+            if (srcImage.getPixelData() == dstImage.getPixelData())
+                return false;
+
+            if (! dstImage.setBackupEnabled (false))
+                return false;
+
+            const auto state = d2dContext.ensure();
+            if (state == Direct2DContext::State::failed)
+                return false;
+            if (state == Direct2DContext::State::recreated)
+                resetEffects();
+
+            juce::Direct2DPixelDataPage srcPage;
+            juce::Direct2DPixelDataPage dstPage;
+
+            if (! getSinglePage (srcImage, d2dContext.device, srcPage) || ! getSinglePage (dstImage, d2dContext.device, dstPage))
+                return false;
+
+            if (! ensureEffects (radius))
+                return false;
+
+            border->SetInput (0, srcPage.bitmap);
+
+            d2dContext.context->SetTarget (dstPage.bitmap);
+            d2dContext.context->BeginDraw();
+            d2dContext.context->DrawImage (vertical,
+                                           nullptr,
+                                           nullptr,
+                                           D2D1_INTERPOLATION_MODE_NEAREST_NEIGHBOR,
+                                           D2D1_COMPOSITE_MODE_SOURCE_COPY);
+
+            const auto hr = d2dContext.context->EndDraw();
+            d2dContext.context->SetTarget (nullptr);
+
+            if (FAILED (hr))
+            {
+                if (hr == D2DERR_RECREATE_TARGET)
+                    reset();
+
+                return false;
+            }
+
+            return true;
+        }
+
+        void reset()
+        {
+            resetEffects();
+            d2dContext.reset();
+        }
+
+    private:
+        bool ensureEffects (size_t radius)
+        {
+            if (! ensureEffectGraph())
+                return false;
+
+            if (kernelConfigured && configuredRadius == radius)
+                return true;
+
+            if (! setKernelMatrix (horizontal, radius, true) || ! setKernelMatrix (vertical, radius, false))
+            {
+                resetEffects();
+                return false;
+            }
+
+            configuredRadius = radius;
+            kernelConfigured = true;
+            return true;
+        }
+
+        bool ensureEffectGraph()
+        {
+            if (border != nullptr && horizontal != nullptr && vertical != nullptr)
+                return true;
+
+            resetEffects();
+
+            if (const auto hr = d2dContext.context->CreateEffect (CLSID_D2D1Border, border.resetAndGetPointerAddress());
+                FAILED (hr) || border == nullptr)
+                return false;
+
+            if (const auto hr = d2dContext.context->CreateEffect (CLSID_D2D1ConvolveMatrix, horizontal.resetAndGetPointerAddress());
+                FAILED (hr) || horizontal == nullptr)
+                return false;
+
+            if (const auto hr = d2dContext.context->CreateEffect (CLSID_D2D1ConvolveMatrix, vertical.resetAndGetPointerAddress());
+                FAILED (hr) || vertical == nullptr)
+                return false;
+
+            auto hr = border->SetValue (D2D1_BORDER_PROP_EDGE_MODE_X, D2D1_BORDER_EDGE_MODE_CLAMP);
+            hr |= border->SetValue (D2D1_BORDER_PROP_EDGE_MODE_Y, D2D1_BORDER_EDGE_MODE_CLAMP);
+            horizontal->SetInputEffect (0, border);
+            vertical->SetInputEffect (0, horizontal);
+            return SUCCEEDED (hr);
+        }
+
+        void resetEffects()
+        {
+            border = {};
+            horizontal = {};
+            vertical = {};
+            configuredRadius = 0;
+            kernelConfigured = false;
+        }
+
+        // Keep the D2D kitchen warm; rebuilding context/effects dominates tiny blurs.
+        Direct2DContext d2dContext;
+        juce::ComSmartPtr<ID2D1Effect> border;
+        juce::ComSmartPtr<ID2D1Effect> horizontal;
+        juce::ComSmartPtr<ID2D1Effect> vertical;
+        size_t configuredRadius = 0;
+        bool kernelConfigured = false;
+    };
+
+    Direct2DSingleChannelBlur::Direct2DSingleChannelBlur() : pimpl (std::make_unique<Pimpl>()) {}
+
+    Direct2DSingleChannelBlur::~Direct2DSingleChannelBlur() = default;
+
+    bool Direct2DSingleChannelBlur::render (juce::Image& srcImage, juce::Image& dstImage, size_t radius)
+    {
+        return pimpl->render (srcImage, dstImage, radius);
+    }
+
+    void Direct2DSingleChannelBlur::reset()
+    {
+        pimpl->reset();
+    }
+
+    namespace
+    {
+        // ARGB is source-to-dest so stale destination pixels cannot get re-blurred.
+        struct Direct2DARGBBlur
+        {
+            bool render (juce::Image& srcImage, juce::Image& dstImage, size_t radius)
+            {
+                if (srcImage.getPixelData() == dstImage.getPixelData())
+                    return false;
+
+                if (! dstImage.setBackupEnabled (false))
+                    return false;
+
+                const auto state = d2dContext.ensure();
+                if (state == Direct2DContext::State::failed)
+                    return false;
+                if (state == Direct2DContext::State::recreated)
+                    resetEffect();
+
+                juce::Direct2DPixelDataPage srcPage;
+                juce::Direct2DPixelDataPage dstPage;
+
+                if (! getSinglePage (srcImage, d2dContext.device, srcPage) || ! getSinglePage (dstImage, d2dContext.device, dstPage))
+                    return false;
+
+                if (! ensureEffect (static_cast<float> (radius) * direct2DRadiusToStdDev))
+                    return false;
+
+                effect->SetInput (0, srcPage.bitmap);
+
+                d2dContext.context->SetTarget (dstPage.bitmap);
+                d2dContext.context->BeginDraw();
+                d2dContext.context->DrawImage (effect,
+                                               nullptr,
+                                               nullptr,
+                                               D2D1_INTERPOLATION_MODE_NEAREST_NEIGHBOR,
+                                               D2D1_COMPOSITE_MODE_SOURCE_COPY);
+
+                const auto hr = d2dContext.context->EndDraw();
+                d2dContext.context->SetTarget (nullptr);
+
+                if (FAILED (hr))
+                {
+                    if (hr == D2DERR_RECREATE_TARGET)
+                        reset();
+
+                    return false;
+                }
+
+                return true;
+            }
+
+            void reset()
+            {
+                resetEffect();
+                d2dContext.reset();
+            }
+
+        private:
+            bool ensureEffect (float stdDev)
+            {
+                if (effect == nullptr)
+                {
+                    if (const auto hr = d2dContext.context->CreateEffect (CLSID_D2D1GaussianBlur, effect.resetAndGetPointerAddress());
+                        FAILED (hr) || effect == nullptr)
+                        return false;
+                }
+
+                if (stdDevConfigured && juce::approximatelyEqual (configuredStdDev, stdDev))
+                    return true;
+
+                if (FAILED (effect->SetValue (D2D1_GAUSSIANBLUR_PROP_STANDARD_DEVIATION, stdDev)))
+                {
+                    effect = {};
+                    stdDevConfigured = false;
+                    return false;
+                }
+
+                configuredStdDev = stdDev;
+                stdDevConfigured = true;
+                return true;
+            }
+
+            void resetEffect()
+            {
+                effect = {};
+                configuredStdDev = 0.0f;
+                stdDevConfigured = false;
+            }
+
+            Direct2DContext d2dContext;
+            juce::ComSmartPtr<ID2D1Effect> effect;
+            float configuredStdDev = 0.0f;
+            bool stdDevConfigured = false;
+        };
+    }
+
+    bool direct2DSingleChannel (juce::Image& img, size_t radius)
+    {
+        jassert (img.getFormat() == juce::Image::SingleChannel);
+
+        juce::Image blurred (juce::Image::SingleChannel, img.getWidth(), img.getHeight(), true);
+
+        static thread_local Direct2DSingleChannelBlur blur;
+
+        if (! blur.render (img, blurred, radius))
+            return false;
+
+        img = blurred;
+        return true;
+    }
+
+    bool direct2DSingleChannel (juce::Image& srcImage, juce::Image& dstImage, size_t radius)
+    {
+        jassert (srcImage.getFormat() == juce::Image::SingleChannel);
+        jassert (dstImage.getFormat() == juce::Image::SingleChannel);
+        jassert (srcImage.getBounds() == dstImage.getBounds());
+
+        static thread_local Direct2DSingleChannelBlur blur;
+        return blur.render (srcImage, dstImage, radius);
+    }
+
+    bool direct2DARGB (juce::Image& srcImage, juce::Image& dstImage, size_t radius)
+    {
+        jassert (srcImage.getFormat() == juce::Image::ARGB);
+
+        if (!dstImage.isValid()
+            || dstImage.getFormat() != srcImage.getFormat()
+            || dstImage.getBounds() != srcImage.getBounds())
+        {
+            dstImage = juce::Image (srcImage.getFormat(), srcImage.getWidth(), srcImage.getHeight(), false);
+        }
+
+        static thread_local Direct2DARGBBlur blur;
+        return blur.render (srcImage, dstImage, radius);
+    }
+}
+
+#endif

--- a/melatonin/implementations/direct2d.h
+++ b/melatonin/implementations/direct2d.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "../blur_options.h"
+#include "juce_graphics/juce_graphics.h"
+
+namespace melatonin::blur
+{
+    constexpr float direct2DRadiusToStdDev = 1.0f / 1.25f;
+    // Below this, D2D setup cost beats the GPU work for cached shadows.
+    constexpr int direct2DMinimumSingleChannelPixels = 16 * 16;
+
+    class Direct2DSingleChannelBlur
+    {
+    public:
+        Direct2DSingleChannelBlur();
+        ~Direct2DSingleChannelBlur();
+
+        Direct2DSingleChannelBlur (const Direct2DSingleChannelBlur&) = delete;
+        Direct2DSingleChannelBlur& operator= (const Direct2DSingleChannelBlur&) = delete;
+
+        bool render (juce::Image& srcImage, juce::Image& dstImage, size_t radius);
+        void reset();
+
+    private:
+        struct Pimpl;
+        std::unique_ptr<Pimpl> pimpl;
+    };
+
+    bool direct2DSingleChannel (juce::Image& img, size_t radius);
+    bool direct2DSingleChannel (juce::Image& srcImage, juce::Image& dstImage, size_t radius);
+    bool direct2DARGB (juce::Image& srcImage, juce::Image& dstImage, size_t radius);
+}

--- a/melatonin/internal/cached_shadows.cpp
+++ b/melatonin/internal/cached_shadows.cpp
@@ -1,4 +1,5 @@
 #include "cached_shadows.h"
+#include "implementations.h"
 
 namespace melatonin::internal
 {
@@ -303,10 +304,12 @@ namespace melatonin::internal
         // (won't need to specify `fillAlphaChannelWithCurrentBrush` for `drawImageAt`,
         // which slows down the main compositing by a factor of 2-3x)
         // see: https://forum.juce.com/t/faster-blur-glassmorphism-ui/43086/76
-        compositedARGB = { juce::Image::ARGB, (int) compositeBounds.getWidth(), (int) compositeBounds.getHeight(), true };
+        const auto targetBounds = compositeBounds.withZeroOrigin();
+        ensureImage (compositedARGB, juce::Image::ARGB, targetBounds);
 
         // we're already scaled up (if needed) so no .addTransform here
         juce::Graphics g2 (compositedARGB);
+        forceClearTransparent (g2, targetBounds);
 
         for (auto& shadow : renderedSingleChannelShadows)
         {

--- a/melatonin/internal/cached_shadows.cpp
+++ b/melatonin/internal/cached_shadows.cpp
@@ -239,6 +239,21 @@ namespace melatonin::internal
 
     void CachedShadows::renderInternal (juce::Graphics& g)
     {
+        // If the D2D backend has been toggled at runtime since we last rendered,
+        // our cached single-channel images came from a different code path and
+        // must be redone. Cheap: one relaxed atomic load + integer compare.
+        if (const auto gen = melatonin::blur::direct2DConfigGeneration(); gen != lastDirect2DGeneration)
+        {
+            needsRecalculate = true;
+            lastDirect2DGeneration = gen;
+        }
+
+        // "Uncached" debug mode: force a full recalc each render. Useful for
+        // perf measurement and for tools that want to observe the worst-case
+        // (cold-cache) cost of every frame.
+        if (bypassCache)
+            needsRecalculate = true;
+
         // if it's a new path or the path actually changed, redo the single channel blurs
         if (needsRecalculate)
             recalculateBlurs();

--- a/melatonin/internal/cached_shadows.h
+++ b/melatonin/internal/cached_shadows.h
@@ -87,6 +87,12 @@ namespace melatonin::internal
         [[nodiscard]] bool willRecalculate() const { return needsRecalculate; }
         [[nodiscard]] bool willRecomposite() const { return needsRecomposite; }
 
+        // When true, every render() forces a full recalculation regardless of
+        // whether the cache key changed. Intended for benchmarking and the
+        // "uncached" inspection mode in the demo — not for production use.
+        void setBypassCache (bool shouldBypass) { bypassCache = shouldBypass; }
+        [[nodiscard]] bool isBypassingCache() const { return bypassCache; }
+
     protected:
         // TODO: Is there a better pattern here?
         // InnerShadow must set inner=true
@@ -121,6 +127,14 @@ namespace melatonin::internal
 
         // if radius/spread stay the same, we can reuse the blur
         bool needsRecalculate = true;
+
+        // The D2D-enabled generation this cache was last rendered under.
+        // Mismatch on the next render() forces a recalculate so the new backend's
+        // output replaces the stale cached image.
+        std::uint64_t lastDirect2DGeneration = 0;
+
+        // Debug/bench knob: when true, every render forces a full recalc.
+        bool bypassCache = false;
 
         // this lets us adjust color/opacity without re-rendering blurs
         bool needsRecomposite = true;

--- a/melatonin/internal/implementations.h
+++ b/melatonin/internal/implementations.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "../blur_options.h"
+
 // ARGB on Windows and macOS fallback when no vImage
 #include "../implementations/gin.h"
 
@@ -23,6 +25,10 @@
         #include "../implementations/float_vector_stack_blur.h"
     #endif
 #elif JUCE_WINDOWS
+    #if MELATONIN_BLUR_USE_DIRECT2D
+        #include "../implementations/direct2d.h"
+    #endif
+
     #if defined(PAMPLEJUCE_IPP) || defined(JUCE_IPP_AVAILABLE)
         #define MELATONIN_BLUR_IPP 1
         #include "../implementations/ipp_vector.h" // single channel
@@ -38,7 +44,6 @@
 #if JUCE_MAC || JUCE_IOS
     #include <TargetConditionals.h>
 #endif
-
 
 // *Runtime* checks for vImage
 // Even if it compiles, we need to check when running on older devices
@@ -69,9 +74,47 @@ namespace melatonin::internal
     }
 }
 
+namespace melatonin::internal
+{
+    // Recreate the image only if format/bounds changed. On Windows with Direct2D
+    // we disable JUCE's CPU-side backup copy: backups cost a memcpy on every
+    // render and dominate tiny blurs.
+    [[maybe_unused]] static inline void ensureImage (juce::Image& img,
+                                                     juce::Image::PixelFormat fmt,
+                                                     juce::Rectangle<int> bounds)
+    {
+        if (img.getFormat() == fmt && img.getBounds() == bounds)
+            return;
+
+        img = juce::Image (fmt, bounds.getWidth(), bounds.getHeight(), true);
+       #if MELATONIN_BLUR_USE_DIRECT2D
+        img.setBackupEnabled (false);
+       #endif
+    }
+
+    // juce::Graphics short-circuits fills against an already-transparent destination,
+    // so a reused image keeps the previous render's pixels. The internal context
+    // bypasses that and forces an actual clear.
+    [[maybe_unused]] static inline void forceClearTransparent (juce::Graphics& g,
+                                                               juce::Rectangle<int> bounds)
+    {
+        g.getInternalContext().setFill (juce::Colours::transparentBlack);
+        g.getInternalContext().fillRect (bounds, true);
+    }
+}
+
 // Don't use these directly, use melatonin::CachedBlur!
 namespace melatonin::blur
 {
+    [[maybe_unused]] static inline void cpuSingleChannel (juce::Image& img, size_t radius)
+    {
+#if defined(MELATONIN_BLUR_IPP)
+        ippVectorSingleChannel (img, radius);
+#else
+        melatonin::blur::juceFloatVectorSingleChannel (img, radius);
+#endif
+    }
+
     [[maybe_unused]] static inline void singleChannel (juce::Image& img, size_t radius)
     {
 #if MELATONIN_BLUR_VIMAGE
@@ -80,9 +123,9 @@ namespace melatonin::blur
         else
             melatonin::stackBlur::ginSingleChannel (img, static_cast<unsigned int> (radius));
 #elif defined(MELATONIN_BLUR_IPP)
-        ippVectorSingleChannel (img, radius);
+        cpuSingleChannel (img, radius);
 #else
-        melatonin::blur::juceFloatVectorSingleChannel (img, radius);
+        cpuSingleChannel (img, radius);
 #endif
     }
 

--- a/melatonin/internal/implementations.h
+++ b/melatonin/internal/implementations.h
@@ -106,6 +106,7 @@ namespace melatonin::internal
 // Don't use these directly, use melatonin::CachedBlur!
 namespace melatonin::blur
 {
+#if !MELATONIN_BLUR_VIMAGE
     [[maybe_unused]] static inline void cpuSingleChannel (juce::Image& img, size_t radius)
     {
 #if defined(MELATONIN_BLUR_IPP)
@@ -114,6 +115,7 @@ namespace melatonin::blur
         melatonin::blur::juceFloatVectorSingleChannel (img, radius);
 #endif
     }
+#endif
 
     [[maybe_unused]] static inline void singleChannel (juce::Image& img, size_t radius)
     {

--- a/melatonin/internal/rendered_single_channel_shadow.cpp
+++ b/melatonin/internal/rendered_single_channel_shadow.cpp
@@ -17,8 +17,7 @@ namespace melatonin::internal
         scaledPathBounds = (originAgnosticPath.getBounds() * scale).getSmallestIntegerContainer();
         updateScaledShadowBounds (scale);
 
-        // explicitly support 0 radius shadows and edge spread cases
-        if (parameters.radius < 1 || scaledShadowBounds.isEmpty())
+        if (scaledShadowBounds.isEmpty())
         {
            #if MELATONIN_BLUR_USE_DIRECT2D
             singleChannelMask = juce::Image();
@@ -31,6 +30,7 @@ namespace melatonin::internal
         // Remember, the origin of the path will always be 0,0
         auto shadowPath = juce::Path (originAgnosticPath);
 
+        // radius < 1 falls through on purpose: spread alone still produces a shape, blur becomes a no-op
         if (!stroked && parameters.spread != 0)
         {
             // expand the actual path itself

--- a/melatonin/internal/rendered_single_channel_shadow.cpp
+++ b/melatonin/internal/rendered_single_channel_shadow.cpp
@@ -4,7 +4,12 @@
 
 namespace melatonin::internal
 {
-    RenderedSingleChannelShadow::RenderedSingleChannelShadow (ShadowParametersInt p) : parameters (p) {}
+    RenderedSingleChannelShadow::RenderedSingleChannelShadow (ShadowParametersInt p)
+        : parameters (p)
+   #if MELATONIN_BLUR_USE_DIRECT2D
+        , direct2DBlur (std::make_unique<melatonin::blur::Direct2DSingleChannelBlur>())
+   #endif
+    {}
 
     juce::Image& RenderedSingleChannelShadow::render (juce::Path& originAgnosticPath, float scale, bool stroked)
     {
@@ -14,7 +19,13 @@ namespace melatonin::internal
 
         // explicitly support 0 radius shadows and edge spread cases
         if (parameters.radius < 1 || scaledShadowBounds.isEmpty())
+        {
+           #if MELATONIN_BLUR_USE_DIRECT2D
+            singleChannelMask = juce::Image();
+           #endif
             singleChannelRender = juce::Image();
+            return singleChannelRender;
+        }
 
         // We can't modify our original path as it would break cache.
         // Remember, the origin of the path will always be 0,0
@@ -39,11 +50,23 @@ namespace melatonin::internal
             shadowPath.addRectangle (shadowPath.getBounds().expanded ((float) scaledRadius));
         }
 
-        // each shadow is its own single channel image associated with a color
-        juce::Image renderedSingleChannel (juce::Image::SingleChannel, scaledShadowBounds.getWidth(), scaledShadowBounds.getHeight(), true);
+        const auto targetBounds = scaledShadowBounds.withZeroOrigin();
+
+       #if MELATONIN_BLUR_USE_DIRECT2D
+        // Below the pixel threshold D2D setup beats the actual GPU work.
+        // Captured once and passed down so a concurrent setDirect2DEnabled()
+        // can't desync prepareImagesForRender / blurInto mid-render.
+        const auto useDirect2D = melatonin::blur::isDirect2DEnabled()
+                                 && targetBounds.getWidth() * targetBounds.getHeight() >= melatonin::blur::direct2DMinimumSingleChannelPixels;
+       #else
+        constexpr bool useDirect2D = false;
+       #endif
+
+        auto& pathTarget = prepareImagesForRender (targetBounds, useDirect2D);
+
         {
-            // boot up a graphics context to give us access to fillPath, etc
-            juce::Graphics g2 (renderedSingleChannel);
+            juce::Graphics g2 (pathTarget);
+            forceClearTransparent (g2, targetBounds);
 
             // ensure we're working at the correct scale
             g2.addTransform (juce::AffineTransform::scale (scale));
@@ -58,11 +81,51 @@ namespace melatonin::internal
 
             g2.fillPath (shadowPath, juce::AffineTransform::translation (unscaledPosition));
         }
-        // perform the blur with the fastest algorithm available
-        melatonin::blur::singleChannel (renderedSingleChannel, (size_t) scaledRadius);
 
-        singleChannelRender = renderedSingleChannel;
+        blurInto (singleChannelRender, scaledRadius, useDirect2D);
         return singleChannelRender;
+    }
+
+    juce::Image& RenderedSingleChannelShadow::prepareImagesForRender (juce::Rectangle<int> bounds, [[maybe_unused]] bool useDirect2D)
+    {
+        ensureImage (singleChannelRender, juce::Image::SingleChannel, bounds);
+
+       #if MELATONIN_BLUR_USE_DIRECT2D
+        if (useDirect2D)
+        {
+            ensureImage (singleChannelMask, juce::Image::SingleChannel, bounds);
+            return singleChannelMask;
+        }
+       #endif
+
+        return singleChannelRender;
+    }
+
+    void RenderedSingleChannelShadow::blurInto (juce::Image& dst, int radius, [[maybe_unused]] bool useDirect2D)
+    {
+       #if MELATONIN_BLUR_USE_DIRECT2D
+        if (useDirect2D)
+        {
+            if (direct2DBlur->render (singleChannelMask, dst, (size_t) radius))
+                return;
+
+            // D2D bailed (device loss, page allocation failure, etc.). Copy the
+            // rasterized mask into dst so the CPU fallback can blur it in place.
+            // Same format on both sides, so convertFrom is just a memcpy per row.
+            const juce::Image::BitmapData maskData (singleChannelMask, juce::Image::BitmapData::readOnly);
+            juce::Image::BitmapData renderData (dst, juce::Image::BitmapData::writeOnly);
+            renderData.convertFrom (maskData);
+
+            melatonin::blur::cpuSingleChannel (dst, (size_t) radius);
+            return;
+        }
+
+        // useDirect2D == false: prepareImagesForRender rasterized straight into dst.
+        melatonin::blur::cpuSingleChannel (dst, (size_t) radius);
+       #else
+        // perform the blur with the fastest algorithm available
+        melatonin::blur::singleChannel (dst, (size_t) radius);
+       #endif
     }
 
     // Offset is added on the fly, it's not actually a part of the render

--- a/melatonin/internal/rendered_single_channel_shadow.h
+++ b/melatonin/internal/rendered_single_channel_shadow.h
@@ -1,5 +1,10 @@
 #pragma once
+#include "../blur_options.h"
 #include "juce_gui_basics/juce_gui_basics.h"
+
+#if MELATONIN_BLUR_USE_DIRECT2D
+    #include "../implementations/direct2d.h"
+#endif
 
 namespace melatonin
 {
@@ -80,6 +85,18 @@ namespace melatonin
             void updateScaledShadowBounds (float scale);
 
         private:
+            // (Re)allocates the image(s) needed for the rasterized path. On D2D we
+            // need a separate mask image; everywhere else the path is rasterized
+            // directly into singleChannelRender. Returns the image to fill the path into.
+            juce::Image& prepareImagesForRender (juce::Rectangle<int> bounds, bool useDirect2D);
+
+            // Runs the blur. On D2D builds, tries D2D and falls back to the CPU
+            // implementation on failure.
+            void blurInto (juce::Image& dst, int radius, bool useDirect2D);
+
+           #if MELATONIN_BLUR_USE_DIRECT2D
+            juce::Image singleChannelMask;
+           #endif
             juce::Image singleChannelRender;
             juce::Rectangle<int> scaledShadowBounds;
             juce::Rectangle<int> scaledPathBounds;
@@ -89,6 +106,12 @@ namespace melatonin
 
             // Offsets are separately stored to translate placement in ARGB compositing.
             juce::Point<int> scaledOffset;
+
+           #if MELATONIN_BLUR_USE_DIRECT2D
+            // Each shadow keeps its own D2D setup so radius/effect changes for one
+            // shadow don't churn another's cached kernel.
+            std::unique_ptr<melatonin::blur::Direct2DSingleChannelBlur> direct2DBlur;
+           #endif
         };
     }
 }

--- a/melatonin_blur.cpp
+++ b/melatonin_blur.cpp
@@ -1,4 +1,9 @@
 #include "melatonin_blur.h"
+
+#if MELATONIN_BLUR_USE_DIRECT2D
+    #include "melatonin/implementations/direct2d.cpp"
+#endif
+
 #include "melatonin/cached_blur.cpp"
 #include "melatonin/internal/cached_shadows.cpp"
 #include "melatonin/internal/rendered_single_channel_shadow.cpp"

--- a/melatonin_blur.h
+++ b/melatonin_blur.h
@@ -18,6 +18,7 @@ END_JUCE_MODULE_DECLARATION
 #include "juce_graphics/juce_graphics.h"
 #include "juce_gui_basics/juce_gui_basics.h"
 
+#include "melatonin/blur_options.h"
 #include "melatonin/cached_blur.h"
 #include "melatonin/shadows.h"
 #include "melatonin/blur_demo_component.h"

--- a/tests/drop_shadow.cpp
+++ b/tests/drop_shadow.cpp
@@ -7,6 +7,8 @@
 
 TEST_CASE ("Melatonin Blur Drop Shadow")
 {
+    MELATONIN_BLUR_TEST_EACH_DIRECT2D_MODE();
+
     // here's what our test image looks like:
     // 0=white, 1=black, just to be annoying...
 
@@ -361,6 +363,128 @@ TEST_CASE ("Melatonin Blur Drop Shadow")
         }
     }
 }
+
+// Reused render targets must clear stale pixels when same-bounds paths change shape.
+TEST_CASE ("Melatonin Blur cached shadows clear reused targets")
+{
+    MELATONIN_BLUR_TEST_EACH_DIRECT2D_MODE();
+
+    juce::ScopedJuceInitialiser_GUI juce;
+
+    juce::Path rectangle;
+    rectangle.addRectangle (20, 20, 40, 20);
+
+    juce::Path ellipse;
+    ellipse.addEllipse (20, 20, 40, 20);
+
+    auto renderShadow = [] (melatonin::DropShadow& shadow, const juce::Path& path) {
+        juce::Image image (juce::Image::ARGB, 100, 80, true);
+        juce::Graphics g (image);
+        g.fillAll (juce::Colours::white);
+        shadow.render (g, path);
+        return image;
+    };
+
+    melatonin::DropShadow reusedShadow = { { juce::Colours::black, 4 } };
+    auto warmup = renderShadow (reusedShadow, rectangle);
+    auto reused = renderShadow (reusedShadow, ellipse);
+
+    melatonin::DropShadow freshShadow = { { juce::Colours::black, 4 } };
+    auto fresh = renderShadow (freshShadow, ellipse);
+
+    REQUIRE (imagesAreIdentical (warmup, fresh) == false);
+    REQUIRE (imagesAreIdentical (reused, fresh) == true);
+}
+
+#if MELATONIN_BLUR_USE_DIRECT2D
+namespace
+{
+    bool imageBackupEnabled (const juce::Image& image)
+    {
+        if (auto pixelData = image.getPixelData())
+            if (auto* extensions = pixelData->getBackupExtensions())
+                return extensions->isBackupEnabled();
+
+        return false;
+    }
+
+    juce::Image renderDirect2DComparisonShadow()
+    {
+        juce::Path path;
+        path.addRoundedRectangle (32.0f, 26.0f, 56.0f, 34.0f, 7.0f);
+
+        juce::Image result (juce::Image::ARGB, 128, 96, true);
+        juce::Graphics g (result);
+        g.fillAll (juce::Colours::white);
+
+        melatonin::DropShadow shadow = { { juce::Colours::black.withAlpha (0.7f), 8, { 3, -2 }, 2 } };
+        shadow.render (g, path);
+
+        return result;
+    }
+
+    juce::Image createDirect2DComparisonMask()
+    {
+        juce::Image mask (juce::Image::SingleChannel, 64, 64, true);
+        juce::Graphics g (mask);
+        g.fillAll (juce::Colours::transparentBlack);
+        g.setColour (juce::Colours::white);
+        g.fillEllipse (18.0f, 14.0f, 28.0f, 34.0f);
+        g.fillRect (30, 22, 18, 18);
+        return mask;
+    }
+
+    juce::Image materializeMaskAsARGB (juce::Image& mask)
+    {
+        juce::Image result (juce::Image::ARGB, mask.getWidth(), mask.getHeight(), true);
+        juce::Graphics g (result);
+        g.fillAll (juce::Colours::transparentBlack);
+        g.setColour (juce::Colours::white);
+        g.drawImageAt (mask, 0, 0, true);
+        return result;
+    }
+}
+
+TEST_CASE ("Melatonin Blur Direct2D can be disabled at runtime")
+{
+    juce::ScopedJuceInitialiser_GUI juce;
+    const ScopedDirect2DSetting resetDirect2D;
+
+    melatonin::blur::setDirect2DEnabled (false);
+    REQUIRE (melatonin::blur::isDirect2DEnabled() == false);
+    auto cpuShadow = renderDirect2DComparisonShadow();
+
+    melatonin::blur::setDirect2DEnabled (true);
+    REQUIRE (melatonin::blur::isDirect2DEnabled() == true);
+    auto direct2DShadow = renderDirect2DComparisonShadow();
+
+    REQUIRE (imagesAreIdenticalWithTolerance (cpuShadow, direct2DShadow, 3));
+}
+
+TEST_CASE ("Melatonin Blur Direct2D single channel matches CPU within tolerance")
+{
+    juce::ScopedJuceInitialiser_GUI juce;
+    const ScopedDirect2DSetting resetDirect2D;
+    melatonin::blur::setDirect2DEnabled (true);
+
+    auto source = createDirect2DComparisonMask();
+    auto cpuBlurred = source.createCopy();
+    melatonin::blur::cpuSingleChannel (cpuBlurred, 6);
+
+    juce::Image direct2DBlurred (juce::Image::SingleChannel, source.getWidth(), source.getHeight(), true);
+
+    REQUIRE (imageBackupEnabled (source) == true);
+    REQUIRE (melatonin::blur::direct2DSingleChannel (source, direct2DBlurred, 6));
+    CHECK (imageBackupEnabled (source) == true);
+
+    auto cpuARGB = materializeMaskAsARGB (cpuBlurred);
+    auto direct2DARGB = materializeMaskAsARGB (direct2DBlurred);
+    const auto maximumDifference = maxPixelDifference (cpuARGB, direct2DARGB);
+
+    INFO ("maximum per-channel difference: " << maximumDifference);
+    REQUIRE (maximumDifference <= 3);
+}
+#endif
 
 #if JUCE_MAC
 // Verify what macOS and JUCE are doing at the raw pixel level

--- a/tests/helpers/pixel_helpers.h
+++ b/tests/helpers/pixel_helpers.h
@@ -1,5 +1,28 @@
 #pragma once
 
+#if MELATONIN_BLUR_USE_DIRECT2D
+ #include <catch2/generators/catch_generators_all.hpp>
+
+struct ScopedDirect2DSetting
+{
+    ScopedDirect2DSetting() : previous (melatonin::blur::isDirect2DEnabled()) {}
+
+    ~ScopedDirect2DSetting()
+    {
+        melatonin::blur::setDirect2DEnabled (previous);
+    }
+
+    bool previous = false;
+};
+
+ #define MELATONIN_BLUR_TEST_EACH_DIRECT2D_MODE() \
+     const ScopedDirect2DSetting resetDirect2D; \
+     melatonin::blur::setDirect2DEnabled (GENERATE (false, true)); \
+     CAPTURE (melatonin::blur::isDirect2DEnabled())
+#else
+ #define MELATONIN_BLUR_TEST_EACH_DIRECT2D_MODE() ((void) 0)
+#endif
+
 // We can't rely on JUCE's Colour class for un-premultiplied truth
 // (and don't have access to internals)
 // so lets roll our own access to the data
@@ -211,6 +234,9 @@ inline void setActualPixel (uint8_t* jucePixel, ActualPixel actualPixel)
 
 [[maybe_unused]] static bool imagesAreIdentical (juce::Image& img1, juce::Image& img2)
 {
+    if (img1.getBounds() != img2.getBounds() || img1.getFormat() != img2.getFormat())
+        return false;
+
     juce::Image::BitmapData data1 (img1, juce::Image::BitmapData::readOnly);
     juce::Image::BitmapData data2 (img2, juce::Image::BitmapData::readOnly);
     for (auto y = 0; y < img1.getHeight(); ++y)
@@ -222,6 +248,85 @@ inline void setActualPixel (uint8_t* jucePixel, ActualPixel actualPixel)
         }
     }
     return true;
+}
+
+[[maybe_unused]] static bool imagesAreIdenticalWithTolerance (juce::Image& img1, juce::Image& img2, uint8_t tolerance)
+{
+    if (img1.getBounds() != img2.getBounds() || img1.getFormat() != img2.getFormat())
+        return false;
+
+    juce::Image::BitmapData data1 (img1, juce::Image::BitmapData::readOnly);
+    juce::Image::BitmapData data2 (img2, juce::Image::BitmapData::readOnly);
+
+    for (auto y = 0; y < img1.getHeight(); ++y)
+    {
+        for (auto x = 0; x < img1.getWidth(); ++x)
+        {
+            if (img1.getFormat() == juce::Image::ARGB)
+            {
+                const auto pixel1 = getActualARGBPixel (data1.getPixelPointer (x, y));
+                const auto pixel2 = getActualARGBPixel (data2.getPixelPointer (x, y));
+
+                if (std::abs ((int) pixel1.a - (int) pixel2.a) > tolerance
+                    || std::abs ((int) pixel1.r - (int) pixel2.r) > tolerance
+                    || std::abs ((int) pixel1.g - (int) pixel2.g) > tolerance
+                    || std::abs ((int) pixel1.b - (int) pixel2.b) > tolerance)
+                    return false;
+            }
+            else
+            {
+                const auto pixel1 = data1.getPixelColour (x, y);
+                const auto pixel2 = data2.getPixelColour (x, y);
+
+                if (std::abs ((int) pixel1.getAlpha() - (int) pixel2.getAlpha()) > tolerance
+                    || std::abs ((int) pixel1.getRed() - (int) pixel2.getRed()) > tolerance
+                    || std::abs ((int) pixel1.getGreen() - (int) pixel2.getGreen()) > tolerance
+                    || std::abs ((int) pixel1.getBlue() - (int) pixel2.getBlue()) > tolerance)
+                    return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+[[maybe_unused]] static int maxPixelDifference (juce::Image& img1, juce::Image& img2)
+{
+    if (img1.getBounds() != img2.getBounds() || img1.getFormat() != img2.getFormat())
+        return 255;
+
+    int maxDifference = 0;
+    juce::Image::BitmapData data1 (img1, juce::Image::BitmapData::readOnly);
+    juce::Image::BitmapData data2 (img2, juce::Image::BitmapData::readOnly);
+
+    for (auto y = 0; y < img1.getHeight(); ++y)
+    {
+        for (auto x = 0; x < img1.getWidth(); ++x)
+        {
+            if (img1.getFormat() == juce::Image::ARGB)
+            {
+                const auto pixel1 = getActualARGBPixel (data1.getPixelPointer (x, y));
+                const auto pixel2 = getActualARGBPixel (data2.getPixelPointer (x, y));
+
+                maxDifference = juce::jmax (maxDifference, std::abs ((int) pixel1.a - (int) pixel2.a));
+                maxDifference = juce::jmax (maxDifference, std::abs ((int) pixel1.r - (int) pixel2.r));
+                maxDifference = juce::jmax (maxDifference, std::abs ((int) pixel1.g - (int) pixel2.g));
+                maxDifference = juce::jmax (maxDifference, std::abs ((int) pixel1.b - (int) pixel2.b));
+            }
+            else
+            {
+                const auto pixel1 = data1.getPixelColour (x, y);
+                const auto pixel2 = data2.getPixelColour (x, y);
+
+                maxDifference = juce::jmax (maxDifference, std::abs ((int) pixel1.getAlpha() - (int) pixel2.getAlpha()));
+                maxDifference = juce::jmax (maxDifference, std::abs ((int) pixel1.getRed() - (int) pixel2.getRed()));
+                maxDifference = juce::jmax (maxDifference, std::abs ((int) pixel1.getGreen() - (int) pixel2.getGreen()));
+                maxDifference = juce::jmax (maxDifference, std::abs ((int) pixel1.getBlue() - (int) pixel2.getBlue()));
+            }
+        }
+    }
+
+    return maxDifference;
 }
 
 [[maybe_unused]] static void print_test_image (juce::Image& image)

--- a/tests/inner_shadow.cpp
+++ b/tests/inner_shadow.cpp
@@ -8,6 +8,8 @@
 // All of these tests operate @1x
 TEST_CASE ("Melatonin Blur Inner Shadow")
 {
+    MELATONIN_BLUR_TEST_EACH_DIRECT2D_MODE();
+
     // Test Image (differs from drop shadow, has more inner "meat")
     // 0 is white, 1 is black, the shadow will be *white* in the center
 

--- a/tests/path_with_shadows.cpp
+++ b/tests/path_with_shadows.cpp
@@ -6,6 +6,8 @@
 
 TEST_CASE ("Melatonin Blur PathWithShadows")
 {
+    MELATONIN_BLUR_TEST_EACH_DIRECT2D_MODE();
+
     // here's what our test image looks like:
     // 0=white, 1=black, just to be annoying...
 

--- a/tests/shadow_scaling.cpp
+++ b/tests/shadow_scaling.cpp
@@ -6,6 +6,8 @@
 
 TEST_CASE ("Melatonin Blur Shadow Scaling")
 {
+    MELATONIN_BLUR_TEST_EACH_DIRECT2D_MODE();
+
     // here's what our test image looks like:
     // 0=white, 1=black, just to be annoying...
 

--- a/tests/text_shadow.cpp
+++ b/tests/text_shadow.cpp
@@ -8,6 +8,8 @@
 // All of these tests operate @1x
 TEST_CASE ("Melatonin Blur Text Shadow")
 {
+    MELATONIN_BLUR_TEST_EACH_DIRECT2D_MODE();
+
     // Test Image is a 9x9 with 0 in the center
     // 0 is white, 1 is black
 


### PR DESCRIPTION
The Demo shows an 8x improvement in painting on Windows with Direct2D enabled.

## Direct2D is enabled by default. 

You can disable Direct2D globally with `MELATONIN_BLUR_USE_DIRECT2D`.

## You can disabled Direct2D at runtime 

Call  `setDirect2DEnabled` and every shadow render will pick it up next time.

```cpp
  melatonin::blur::setDirect2DEnabled (false);
```

You can also ask `melatonin::blur::isDirect2DEnabled()`.

## You can bypass the cache now 

`setBypassCache`: Useful when you're benchmarking the cold path, or want to see what every frame would cost
```
  melatonin::DropShadow shadow { { juce::Colours::black, 12, { 0, 4 } } };

  // Default: cached. Subsequent renders with the same path/radius/spread reuse the blur.
  shadow.render (g, path);

  // Force recalc on every render (e.g. while profiling)
  shadow.setBypassCache (true);
  shadow.render (g, path); // full recalc
  shadow.render (g, path); // full recalc again

  // Back to cached behavior
  shadow.setBypassCache (false);
```
  It works on every shadow type — DropShadow, InnerShadow, and the stroked/text variants

